### PR TITLE
Update LDAP wizard to use new DDF config

### DIFF
--- a/query/security/common/src/main/java/org/codice/ddf/admin/security/common/services/LdapLoginServiceProperties.java
+++ b/query/security/common/src/main/java/org/codice/ddf/admin/security/common/services/LdapLoginServiceProperties.java
@@ -32,7 +32,7 @@ public class LdapLoginServiceProperties {
   //    public static final String KDC_ADDRESS = "kdcAddress"
   public static final String REALM = "realm";
 
-  public static final String LOGIN_USER_ATTRIBUTE = "loginUserAtttribute";
+  public static final String LOGIN_USER_ATTRIBUTE = "loginUserAttribute";
 
   public static final String MEMBERSHIP_USER_ATTRIBUTE = "membershipUserAttribute";
 

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/commons/LdapServiceCommons.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/commons/LdapServiceCommons.java
@@ -46,6 +46,7 @@ import org.codice.ddf.configuration.PropertyResolver;
 import org.codice.ddf.internal.admin.configurator.actions.ConfiguratorSuite;
 
 public class LdapServiceCommons {
+
   private static final Pattern URI_MATCHER = Pattern.compile("\\w*://.*");
 
   private final ConfiguratorSuite configuratorSuite;
@@ -101,7 +102,7 @@ public class LdapServiceCommons {
           LdapClaimsHandlerServiceProperties.BIND_METHOD, config.bindUserInfoField().bindMethod());
       props.put(
           LdapClaimsHandlerServiceProperties.LOGIN_USER_ATTRIBUTE,
-          config.settingsField().usernameAttribute());
+          config.settingsField().loginUserAttribute());
       props.put(
           LdapClaimsHandlerServiceProperties.USER_BASE_DN, config.settingsField().baseUserDn());
       props.put(
@@ -144,15 +145,11 @@ public class LdapServiceCommons {
 
       ldapStsConfig.put(
           LdapLoginServiceProperties.LOGIN_USER_ATTRIBUTE,
-          config.settingsField().usernameAttribute());
+          config.settingsField().loginUserAttribute());
 
-      // TODO: oconnormi - 10/02/17 The ui needs to be updated to include a field for the group
-      // member user attribute
       ldapStsConfig.put(
           LdapLoginServiceProperties.MEMBERSHIP_USER_ATTRIBUTE,
-          config.settingsField().groupAttributeHoldingMember() == null
-              ? config.settingsField().usernameAttribute()
-              : config.settingsField().groupAttributeHoldingMember());
+          config.settingsField().memberAttributeReferencedInGroup());
 
       ldapStsConfig.put(
           LdapLoginServiceProperties.USER_BASE_DN, config.settingsField().baseUserDn());
@@ -177,15 +174,15 @@ public class LdapServiceCommons {
 
     LdapDirectorySettingsField settings =
         new LdapDirectorySettingsField()
-            .usernameAttribute(
+            .loginUserAttribute(
                 mapValue(props, LdapClaimsHandlerServiceProperties.LOGIN_USER_ATTRIBUTE))
             .baseUserDn(mapValue(props, LdapClaimsHandlerServiceProperties.USER_BASE_DN))
             .baseGroupDn(mapValue(props, LdapClaimsHandlerServiceProperties.GROUP_BASE_DN))
             .groupObjectClass(mapValue(props, LdapClaimsHandlerServiceProperties.OBJECT_CLASS))
             .groupAttributeHoldingMember(
-                mapValue(props, LdapClaimsHandlerServiceProperties.MEMBERSHIP_USER_ATTRIBUTE))
-            .memberAttributeReferencedInGroup(
                 mapValue(props, LdapClaimsHandlerServiceProperties.MEMBER_NAME_ATTRIBUTE))
+            .memberAttributeReferencedInGroup(
+                mapValue(props, LdapClaimsHandlerServiceProperties.MEMBERSHIP_USER_ATTRIBUTE))
             .useCase(ATTRIBUTE_STORE);
 
     Map<String, String> claimMappings = Collections.emptyMap();
@@ -226,8 +223,8 @@ public class LdapServiceCommons {
 
     LdapDirectorySettingsField settings =
         new LdapDirectorySettingsField()
-            .usernameAttribute(mapValue(props, LdapLoginServiceProperties.LOGIN_USER_ATTRIBUTE))
-            .groupAttributeHoldingMember(
+            .loginUserAttribute(mapValue(props, LdapLoginServiceProperties.LOGIN_USER_ATTRIBUTE))
+            .memberAttributeReferencedInGroup(
                 mapValue(props, LdapLoginServiceProperties.MEMBERSHIP_USER_ATTRIBUTE))
             .baseUserDn(mapValue(props, LdapLoginServiceProperties.USER_BASE_DN))
             .baseGroupDn(mapValue(props, LdapLoginServiceProperties.GROUP_BASE_DN))

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/commons/ServerGuesser.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/commons/ServerGuesser.java
@@ -121,7 +121,7 @@ public abstract class ServerGuesser {
     }
   }
 
-  public List<String> getUserNameAttribute() {
+  public List<String> getLoginUserAttribute() {
     return ImmutableList.of("uid");
   }
 
@@ -264,7 +264,7 @@ public abstract class ServerGuesser {
     }
 
     @Override
-    public List<String> getUserNameAttribute() {
+    public List<String> getLoginUserAttribute() {
       return Collections.singletonList("sAMAccountName");
     }
 

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapRecommendedSettings.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapRecommendedSettings.java
@@ -83,7 +83,7 @@ public class LdapRecommendedSettings extends BaseFunctionField<LdapRecommendedSe
       return new LdapRecommendedSettingsField()
           .userDns(guesser.getUserBaseChoices())
           .groupDns(guesser.getGroupBaseChoices())
-          .userNameAttributes(guesser.getUserNameAttribute())
+          .loginUserAttributes(guesser.getLoginUserAttribute())
           .groupObjectClasses(guesser.getGroupObjectClass())
           .groupAttributesHoldingMember(guesser.getGroupAttributeHoldingMember())
           .memberAttributesReferencedInGroup(guesser.getMemberAttributeReferencedInGroup())

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestClaimMappings.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestClaimMappings.java
@@ -54,7 +54,7 @@ public class LdapTestClaimMappings extends TestFunctionField {
   public static final String DESCRIPTION =
       "Tests whether the attributes mapped to claims exist on users beneath the user base.";
 
-  public static final String USER_NAME_ATTRIBUTE = "userNameAttribute";
+  public static final String LOGIN_USER_ATTRIBUTE = "loginUserAttribute";
 
   public static final String BASE_USER_DN = "baseUserDn";
 
@@ -64,7 +64,7 @@ public class LdapTestClaimMappings extends TestFunctionField {
 
   private LdapBindUserInfo bindInfo;
 
-  private LdapAttributeName usernameAttribute;
+  private LdapAttributeName loginUserAttribute;
 
   private LdapDistinguishedName baseUserDn;
 
@@ -80,7 +80,7 @@ public class LdapTestClaimMappings extends TestFunctionField {
 
     conn = new LdapConnectionField().useDefaultRequired();
     bindInfo = new LdapBindUserInfo().useDefaultRequired();
-    usernameAttribute = new LdapAttributeName(USER_NAME_ATTRIBUTE).isRequired(true);
+    loginUserAttribute = new LdapAttributeName(LOGIN_USER_ATTRIBUTE).isRequired(true);
     baseUserDn = new LdapDistinguishedName(BASE_USER_DN);
     baseUserDn.isRequired(true);
     claimMappings = new ClaimsMapEntry.ListImpl();
@@ -93,7 +93,7 @@ public class LdapTestClaimMappings extends TestFunctionField {
 
   @Override
   public List<Field> getArguments() {
-    return ImmutableList.of(conn, bindInfo, usernameAttribute, baseUserDn, claimMappings);
+    return ImmutableList.of(conn, bindInfo, loginUserAttribute, baseUserDn, claimMappings);
   }
 
   @Override
@@ -185,7 +185,7 @@ public class LdapTestClaimMappings extends TestFunctionField {
         .getLdapQueryResults(
             ldapConnection,
             baseUserDn.getValue(),
-            Filter.and(Filter.present(usernameAttribute.getValue()), Filter.present(mapAttribute))
+            Filter.and(Filter.present(loginUserAttribute.getValue()), Filter.present(mapAttribute))
                 .toString(),
             SearchScope.WHOLE_SUBTREE,
             1)

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestDirectorySettings.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestDirectorySettings.java
@@ -157,13 +157,13 @@ public class LdapTestDirectorySettings extends TestFunctionField {
         utils.getLdapQueryResults(
             ldapConnection,
             settings.baseUserDn(),
-            Filter.present(settings.usernameAttribute()).toString(),
+            Filter.present(settings.loginUserAttribute()).toString(),
             SearchScope.WHOLE_SUBTREE,
             1);
 
     if (baseUsersResults.isEmpty()) {
       addErrorMessage(noUsersInBaseUserDnError(settings.baseUserDnField().getPath()));
-      addErrorMessage(userAttributeNotFoundError(settings.usernameAttributeField().getPath()));
+      addErrorMessage(userAttributeNotFoundError(settings.loginUserAttributeField().getPath()));
     }
   }
 

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/config/LdapDirectorySettingsField.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/config/LdapDirectorySettingsField.java
@@ -30,7 +30,7 @@ public class LdapDirectorySettingsField extends BaseObjectField {
   public static final String DESCRIPTION =
       "Contains information about the LDAP structure and various attributes required to setup.";
 
-  public static final String USER_NAME_ATTRIBUTE = "userNameAttribute";
+  public static final String LOGIN_USER_ATTRIBUTE = "loginUserAttribute";
 
   public static final String BASE_USER_DN = "baseUserDn";
 
@@ -43,7 +43,7 @@ public class LdapDirectorySettingsField extends BaseObjectField {
   public static final String MEMBER_ATTRIBUTE_REFERENCED_IN_GROUP =
       "memberAttributeReferencedInGroup";
 
-  private LdapAttributeName usernameAttribute;
+  private LdapAttributeName loginUserAttribute;
 
   private LdapDistinguishedName baseUserDn;
 
@@ -60,7 +60,7 @@ public class LdapDirectorySettingsField extends BaseObjectField {
   public LdapDirectorySettingsField() {
     super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
 
-    this.usernameAttribute = new LdapAttributeName(USER_NAME_ATTRIBUTE);
+    this.loginUserAttribute = new LdapAttributeName(LOGIN_USER_ATTRIBUTE);
     this.baseUserDn = new LdapDistinguishedName(BASE_USER_DN);
     this.baseGroupDn = new LdapDistinguishedName(BASE_GROUP_DN);
     this.groupObjectClass = new StringField(GROUP_OBJECT_CLASS);
@@ -73,7 +73,7 @@ public class LdapDirectorySettingsField extends BaseObjectField {
   @Override
   public List<Field> getFields() {
     return ImmutableList.of(
-        usernameAttribute,
+        loginUserAttribute,
         baseUserDn,
         baseGroupDn,
         groupObjectClass,
@@ -83,8 +83,8 @@ public class LdapDirectorySettingsField extends BaseObjectField {
   }
 
   // Field getters
-  public LdapAttributeName usernameAttributeField() {
-    return usernameAttribute;
+  public LdapAttributeName loginUserAttributeField() {
+    return loginUserAttribute;
   }
 
   public LdapUseCase useCaseField() {
@@ -124,8 +124,8 @@ public class LdapDirectorySettingsField extends BaseObjectField {
     return groupObjectClass.getValue();
   }
 
-  public String usernameAttribute() {
-    return usernameAttribute.getValue();
+  public String loginUserAttribute() {
+    return loginUserAttribute.getValue();
   }
 
   public String groupAttributeHoldingMember() {
@@ -138,7 +138,7 @@ public class LdapDirectorySettingsField extends BaseObjectField {
 
   public LdapDirectorySettingsField useDefaultRequiredForAuthentication() {
     baseUserDn.isRequired(true);
-    usernameAttribute.isRequired(true);
+    loginUserAttribute.isRequired(true);
     useCase.isRequired(true);
     baseGroupDn.isRequired(true);
     isRequired(true);
@@ -173,8 +173,8 @@ public class LdapDirectorySettingsField extends BaseObjectField {
     return this;
   }
 
-  public LdapDirectorySettingsField usernameAttribute(String usernameAttribute) {
-    this.usernameAttribute.setValue(usernameAttribute);
+  public LdapDirectorySettingsField loginUserAttribute(String loginUserAttribute) {
+    this.loginUserAttribute.setValue(loginUserAttribute);
     return this;
   }
 

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/query/LdapRecommendedSettingsField.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/query/LdapRecommendedSettingsField.java
@@ -33,7 +33,7 @@ public class LdapRecommendedSettingsField extends BaseObjectField {
 
   private static final String GROUPS_DNS = "groupsDns";
 
-  private static final String USER_NAME_ATTRIBUTES = "userNameAttributes";
+  private static final String LOGIN_USER_ATTRIBUTES = "loginUserAttributes";
 
   private static final String GROUP_OBJECT_CLASSES = "groupObjectClasses";
 
@@ -48,7 +48,7 @@ public class LdapRecommendedSettingsField extends BaseObjectField {
 
   private LdapDistinguishedName.ListImpl groupDns;
 
-  private StringField.ListImpl userNameAttributes;
+  private StringField.ListImpl loginUserAttributes;
 
   private StringField.ListImpl groupObjectClasses;
 
@@ -62,7 +62,7 @@ public class LdapRecommendedSettingsField extends BaseObjectField {
     super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
     userDns = new LdapDistinguishedName.ListImpl(USER_DNS);
     groupDns = new LdapDistinguishedName.ListImpl(GROUPS_DNS);
-    userNameAttributes = new StringField.ListImpl(USER_NAME_ATTRIBUTES);
+    loginUserAttributes = new StringField.ListImpl(LOGIN_USER_ATTRIBUTES);
     groupObjectClasses = new StringField.ListImpl(GROUP_OBJECT_CLASSES);
     groupAttributesHoldingMember = new StringField.ListImpl(GROUP_ATTRIBUTES_HOLDING_MEMBER);
     memberAttributesReferencedInGroup =
@@ -79,8 +79,8 @@ public class LdapRecommendedSettingsField extends BaseObjectField {
     return groupDns;
   }
 
-  public ListField<StringField> userNameAttributesField() {
-    return userNameAttributes;
+  public ListField<StringField> loginUserAttributesField() {
+    return loginUserAttributes;
   }
 
   public ListField<StringField> groupObjectClassesField() {
@@ -110,8 +110,8 @@ public class LdapRecommendedSettingsField extends BaseObjectField {
     return this;
   }
 
-  public LdapRecommendedSettingsField userNameAttributes(List<String> userNameAttributes) {
-    this.userNameAttributes.setValue(userNameAttributes);
+  public LdapRecommendedSettingsField loginUserAttributes(List<String> loginUserAttributes) {
+    this.loginUserAttributes.setValue(loginUserAttributes);
     return this;
   }
 
@@ -142,7 +142,7 @@ public class LdapRecommendedSettingsField extends BaseObjectField {
     return ImmutableList.of(
         userDns,
         groupDns,
-        userNameAttributes,
+        loginUserAttributes,
         groupObjectClasses,
         groupAttributesHoldingMember,
         memberAttributesReferencedInGroup,

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/CreateLdapConfigurationSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/CreateLdapConfigurationSpec.groovy
@@ -49,7 +49,7 @@ class CreateLdapConfigurationSpec extends Specification {
                         missingUseCasePath     : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapUseCase.DEFAULT_FIELD_NAME],
                         missingUserPath        : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.BASE_USER_DN],
                         missingGroupPath       : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.BASE_GROUP_DN],
-                        missingUserNameAttrPath: baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.USER_NAME_ATTRIBUTE],
+                        missingLoginUserAttrPath: baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.LOGIN_USER_ATTRIBUTE],
                         missingGroupObjectPath : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.GROUP_OBJECT_CLASS],
                         missingGroupAttribPath : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.GROUP_ATTRIBUTE_HOLDING_MEMBER],
                         missingMemberAttribPath: baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.MEMBER_ATTRIBUTE_REFERENCED_IN_GROUP],
@@ -89,7 +89,7 @@ class CreateLdapConfigurationSpec extends Specification {
                                                 authBadPaths.missingUseCasePath,
                                                 authBadPaths.missingUserPath,
                                                 authBadPaths.missingGroupPath,
-                                                authBadPaths.missingUserNameAttrPath] as Set
+                                                authBadPaths.missingLoginUserAttrPath] as Set
     }
 
     def 'fail on missing required fields for attribute store'() {
@@ -113,7 +113,7 @@ class CreateLdapConfigurationSpec extends Specification {
                                                 authBadPaths.missingBindMethodPath,
                                                 authBadPaths.missingUserPath,
                                                 authBadPaths.missingGroupPath,
-                                                authBadPaths.missingUserNameAttrPath,
+                                                authBadPaths.missingLoginUserAttrPath,
                                                 attributeStoreBadPaths.missingGroupAttributeHoldingMemberPath,
                                                 attributeStoreBadPaths.missingGroupObjectClassPath,
                                                 attributeStoreBadPaths.missingMemberAttributeReferencedInGroupPath,

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapRecommendedSettingsSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapRecommendedSettingsSpec.groovy
@@ -149,8 +149,8 @@ class LdapRecommendedSettingsSpec extends Specification {
             it == 'ou=groups,dc=example,dc=com'
         }
 
-        recSettings.userNameAttributesField().value.size() == 1
-        recSettings.userNameAttributesField().value.first() == 'uid'
+        recSettings.loginUserAttributesField().value.size() == 1
+        recSettings.loginUserAttributesField().value.first() == 'uid'
 
         recSettings.groupObjectClassesField().value.collect {
             it.toLowerCase()

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestClaimMappingsSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestClaimMappingsSpec.groovy
@@ -89,7 +89,7 @@ class LdapTestClaimMappingsSpec extends Specification {
 
         // Initialize bad paths
         baseMsg = [LdapTestClaimMappings.FIELD_NAME]
-        badPaths = [badOrMissingUserNameAttrPath: baseMsg + [LdapDirectorySettingsField.USER_NAME_ATTRIBUTE],
+        badPaths = [badOrMissingLoginUserAttrPath: baseMsg + [LdapDirectorySettingsField.LOGIN_USER_ATTRIBUTE],
                     missingUserPath             : baseMsg + [LdapDirectorySettingsField.BASE_USER_DN],
                     missingHostPath             : baseMsg + [LdapConnectionField.DEFAULT_FIELD_NAME, HostnameField.DEFAULT_FIELD_NAME],
                     missingPortPath             : baseMsg + [LdapConnectionField.DEFAULT_FIELD_NAME, PortField.DEFAULT_FIELD_NAME],
@@ -126,7 +126,7 @@ class LdapTestClaimMappingsSpec extends Specification {
 
         args = [(LdapConnectionField.DEFAULT_FIELD_NAME)   : noEncryptionLdapConnectionInfo().getValue(),
                 (LdapBindUserInfo.DEFAULT_FIELD_NAME)      : simpleBindInfo().getValue(),
-                (LdapTestClaimMappings.USER_NAME_ATTRIBUTE): userAttribute.getValue(),
+                (LdapTestClaimMappings.LOGIN_USER_ATTRIBUTE): userAttribute.getValue(),
                 (LdapTestClaimMappings.BASE_USER_DN)       : baseDn.getValue(),
                 (CLAIMS_MAPPING)                           : createClaimsMapping(ImmutableMap.of("claim1", "cn")).getValue()]
 
@@ -147,7 +147,7 @@ class LdapTestClaimMappingsSpec extends Specification {
 
         args = [(LdapConnectionField.DEFAULT_FIELD_NAME)   : noEncryptionLdapConnectionInfo().port(666).getValue(),
                 (LdapBindUserInfo.DEFAULT_FIELD_NAME)      : simpleBindInfo().getValue(),
-                (LdapTestClaimMappings.USER_NAME_ATTRIBUTE): userAttribute.getValue(),
+                (LdapTestClaimMappings.LOGIN_USER_ATTRIBUTE): userAttribute.getValue(),
                 (LdapTestClaimMappings.BASE_USER_DN)       : baseDn.getValue(),
                 (CLAIMS_MAPPING)                           : createClaimsMapping(ImmutableMap.of("claim1", "cn")).getValue()]
 
@@ -166,7 +166,7 @@ class LdapTestClaimMappingsSpec extends Specification {
 
         args = [(LdapConnectionField.DEFAULT_FIELD_NAME)   : noEncryptionLdapConnectionInfo().getValue(),
                 (LdapBindUserInfo.DEFAULT_FIELD_NAME)      : simpleBindInfo().password('badPassword').getValue(),
-                (LdapTestClaimMappings.USER_NAME_ATTRIBUTE): userAttribute.getValue(),
+                (LdapTestClaimMappings.LOGIN_USER_ATTRIBUTE): userAttribute.getValue(),
                 (LdapTestClaimMappings.BASE_USER_DN)       : baseDn.getValue(),
                 (CLAIMS_MAPPING)                           : createClaimsMapping(ImmutableMap.of("claim1", "cn")).getValue()]
 
@@ -186,7 +186,7 @@ class LdapTestClaimMappingsSpec extends Specification {
 
         args = [(LdapConnectionField.DEFAULT_FIELD_NAME)   : noEncryptionLdapConnectionInfo().getValue(),
                 (LdapBindUserInfo.DEFAULT_FIELD_NAME)      : simpleBindInfo().getValue(),
-                (LdapTestClaimMappings.USER_NAME_ATTRIBUTE): userAttribute.getValue(),
+                (LdapTestClaimMappings.LOGIN_USER_ATTRIBUTE): userAttribute.getValue(),
                 (LdapTestClaimMappings.BASE_USER_DN)       : baseDn.getValue(),
                 (CLAIMS_MAPPING)                           : createClaimsMapping(ImmutableMap.of("claim1", "cn")).getValue()]
 
@@ -212,7 +212,7 @@ class LdapTestClaimMappingsSpec extends Specification {
                 "claim3", "sn"))
         args = [(LdapConnectionField.DEFAULT_FIELD_NAME)   : noEncryptionLdapConnectionInfo().getValue(),
                 (LdapBindUserInfo.DEFAULT_FIELD_NAME)      : simpleBindInfo().getValue(),
-                (LdapTestClaimMappings.USER_NAME_ATTRIBUTE): userAttribute.getValue(),
+                (LdapTestClaimMappings.LOGIN_USER_ATTRIBUTE): userAttribute.getValue(),
                 (LdapTestClaimMappings.BASE_USER_DN)       : baseDn.getValue(),
                 (CLAIMS_MAPPING)                           : claimsMapping.getValue()]
 
@@ -239,7 +239,7 @@ class LdapTestClaimMappingsSpec extends Specification {
                 "claim4", "employeetype"))
         args = [(LdapConnectionField.DEFAULT_FIELD_NAME)   : noEncryptionLdapConnectionInfo().getValue(),
                 (LdapBindUserInfo.DEFAULT_FIELD_NAME)      : simpleBindInfo().getValue(),
-                (LdapTestClaimMappings.USER_NAME_ATTRIBUTE): userAttribute.getValue(),
+                (LdapTestClaimMappings.LOGIN_USER_ATTRIBUTE): userAttribute.getValue(),
                 (LdapTestClaimMappings.BASE_USER_DN)       : baseDn.getValue(),
                 (CLAIMS_MAPPING)                           : claimsMapping.getValue()]
 
@@ -270,7 +270,7 @@ class LdapTestClaimMappingsSpec extends Specification {
 
         args = [(LdapConnectionField.DEFAULT_FIELD_NAME)   : noEncryptionLdapConnectionInfo().getValue(),
                 (LdapBindUserInfo.DEFAULT_FIELD_NAME)      : simpleBindInfo().getValue(),
-                (LdapTestClaimMappings.USER_NAME_ATTRIBUTE): userAttribute.getValue(),
+                (LdapTestClaimMappings.LOGIN_USER_ATTRIBUTE): userAttribute.getValue(),
                 (LdapTestClaimMappings.BASE_USER_DN)       : baseDn.getValue(),
                 (CLAIMS_MAPPING)                           : claimsMapping.getValue()]
 
@@ -286,9 +286,9 @@ class LdapTestClaimMappingsSpec extends Specification {
         report.getErrorMessages()*.path as Set == failedPaths
     }
 
-    def 'fail when usernameAttribute format is incorrect'() {
+    def 'fail when loginUserAttribute format is incorrect'() {
         setup:
-        def failedPaths = [badPaths.badOrMissingUserNameAttrPath] as Set
+        def failedPaths = [badPaths.badOrMissingLoginUserAttrPath] as Set
 
         def claimsMapping = createClaimsMapping(ImmutableMap.of("claim1", "sn",
                 "claim2", "cn",
@@ -298,7 +298,7 @@ class LdapTestClaimMappingsSpec extends Specification {
 
         args = [(LdapConnectionField.DEFAULT_FIELD_NAME)   : noEncryptionLdapConnectionInfo().getValue(),
                 (LdapBindUserInfo.DEFAULT_FIELD_NAME)      : simpleBindInfo().getValue(),
-                (LdapTestClaimMappings.USER_NAME_ATTRIBUTE): userAttribute,
+                (LdapTestClaimMappings.LOGIN_USER_ATTRIBUTE): userAttribute,
                 (LdapTestClaimMappings.BASE_USER_DN)       : baseDn.getValue(),
                 (CLAIMS_MAPPING)                           : claimsMapping.getValue()]
 
@@ -322,7 +322,7 @@ class LdapTestClaimMappingsSpec extends Specification {
 
         args = [(LdapConnectionField.DEFAULT_FIELD_NAME)   : noEncryptionLdapConnectionInfo().getValue(),
                 (LdapBindUserInfo.DEFAULT_FIELD_NAME)      : simpleBindInfo().getValue(),
-                (LdapTestClaimMappings.USER_NAME_ATTRIBUTE): userAttribute.getValue(),
+                (LdapTestClaimMappings.LOGIN_USER_ATTRIBUTE): userAttribute.getValue(),
                 (LdapTestClaimMappings.BASE_USER_DN)       : baseDn.getValue(),
                 (CLAIMS_MAPPING)                           : claimsMapping.getValue()]
 

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestDirectorySettingsSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestDirectorySettingsSpec.groovy
@@ -69,13 +69,13 @@ class LdapTestDirectorySettingsSpec extends Specification {
                     missingUseCasePath         : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapUseCase.DEFAULT_FIELD_NAME],
                     missingUserPath            : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.BASE_USER_DN],
                     missingGroupPath           : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.BASE_GROUP_DN],
-                    missingUserNameAttrPath    : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.USER_NAME_ATTRIBUTE],
+                    missingLoginUserAttrPath    : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.LOGIN_USER_ATTRIBUTE],
                     missingGroupObjectPath     : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.GROUP_OBJECT_CLASS],
                     missingGroupAttribPath     : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.GROUP_ATTRIBUTE_HOLDING_MEMBER],
                     missingMemberAttribPath    : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.MEMBER_ATTRIBUTE_REFERENCED_IN_GROUP],
                     badUserDnPath              : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.BASE_USER_DN],
                     badGroupDnPath             : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.BASE_GROUP_DN],
-                    badUserNameAttribFormatPath: baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.USER_NAME_ATTRIBUTE],
+                    badLoginUserAttribFormatPath: baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.LOGIN_USER_ATTRIBUTE],
                     badGroupAttribFormatPath   : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.GROUP_ATTRIBUTE_HOLDING_MEMBER],
                     badMemberAttribFormatPath  : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.MEMBER_ATTRIBUTE_REFERENCED_IN_GROUP]
         ]
@@ -107,7 +107,7 @@ class LdapTestDirectorySettingsSpec extends Specification {
                                                 badPaths.missingUseCasePath,
                                                 badPaths.missingUserPath,
                                                 badPaths.missingGroupPath,
-                                                badPaths.missingUserNameAttrPath] as Set
+                                                badPaths.missingLoginUserAttrPath] as Set
     }
 
     def 'fail on missing required fields for LDAP Attribute Store'() {
@@ -292,14 +292,14 @@ class LdapTestDirectorySettingsSpec extends Specification {
         } == 1
 
         report.getErrorMessages()*.getPath() as Set == [badPaths.badUserDnPath,
-                                                badPaths.missingUserNameAttrPath] as Set
+                                                badPaths.missingLoginUserAttrPath] as Set
         ldapConnectionIsClosed
     }
 
-    def 'fail when the usernameAttribute format is incorrect'() {
+    def 'fail when the loginUserAttribute format is incorrect'() {
         setup:
         def ldapSettings = initLdapSettings(ATTRIBUTE_STORE, true)
-                .usernameAttribute("space & speci@l ch@r@cters")
+                .loginUserAttribute("space & speci@l ch@r@cters")
 
         args = [(LdapConnectionField.DEFAULT_FIELD_NAME)       : noEncryptionLdapConnectionInfo().getValue(),
                 (LdapBindUserInfo.DEFAULT_FIELD_NAME)          : simpleBindInfo().getValue(),
@@ -315,7 +315,7 @@ class LdapTestDirectorySettingsSpec extends Specification {
             it.getCode() == LdapMessages.INVALID_USER_ATTRIBUTE
         } == 1
 
-        report.getErrorMessages()*.getPath() as Set == [badPaths.badUserNameAttribFormatPath] as Set
+        report.getErrorMessages()*.getPath() as Set == [badPaths.badLoginUserAttribFormatPath] as Set
     }
 
     def 'fail when the groupAttributeHoldingMember format is incorrect'() {

--- a/query/security/ldap/src/test/java/org/codice/ddf/admin/ldap/LdapTestingCommons.java
+++ b/query/security/ldap/src/test/java/org/codice/ddf/admin/ldap/LdapTestingCommons.java
@@ -56,7 +56,7 @@ public class LdapTestingCommons {
       String useCase, boolean includeAttributeFields) {
     LdapDirectorySettingsField settingsField =
         new LdapDirectorySettingsField()
-            .usernameAttribute("sn")
+            .loginUserAttribute("sn")
             .baseUserDn(LDAP_SERVER_BASE_USER_DN)
             .baseGroupDn(LDAP_SERVER_BASE_GROUP_DN)
             .useCase(useCase);

--- a/tests/itests/src/test/java/org/codice/ddf/admin/query/AdminSecurityIT.java
+++ b/tests/itests/src/test/java/org/codice/ddf/admin/query/AdminSecurityIT.java
@@ -55,6 +55,7 @@ import org.ops4j.pax.exam.spi.reactors.PerClass;
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 public class AdminSecurityIT extends AbstractComponentTest {
+
   @Override
   public List<Option> customSettings() {
     return super.customSettings();
@@ -155,8 +156,6 @@ public class AdminSecurityIT extends AbstractComponentTest {
   /**
    * For the user's convenience, identical policy bins are collapsed into a single policy bin. This
    * test confirms two policies bins can be persisted and retrieved as a single collapsed policy
-   *
-   * @throws IOException
    */
   @Test
   public void savePolicies() throws IOException {
@@ -261,8 +260,8 @@ public class AdminSecurityIT extends AbstractComponentTest {
     LdapDirectorySettingsField dirSettings =
         new LdapDirectorySettingsField()
             .baseUserDn(TEST_DN)
-            .usernameAttribute(TEST_ATTRIBUTE)
-            .groupAttributeHoldingMember(TEST_ATTRIBUTE)
+            .loginUserAttribute(TEST_ATTRIBUTE)
+            .memberAttributeReferencedInGroup(TEST_ATTRIBUTE)
             .baseGroupDn(TEST_DN)
             .useCase(ldapUseCase.getValue());
 
@@ -270,7 +269,7 @@ public class AdminSecurityIT extends AbstractComponentTest {
         || ldapUseCase
             .getValue()
             .equals(LdapUseCase.AUTHENTICATION_AND_ATTRIBUTE_STORE.getValue())) {
-      dirSettings.groupObjectClass(TEST_ATTRIBUTE).memberAttributeReferencedInGroup(TEST_ATTRIBUTE);
+      dirSettings.groupObjectClass(TEST_ATTRIBUTE).groupAttributeHoldingMember(TEST_ATTRIBUTE);
 
       newConfig.claimMappingsField(
           new ClaimsMapEntry.ListImpl()

--- a/tests/itests/src/test/resources/query/ldap/query/GetLdapConfigs.graphql
+++ b/tests/itests/src/test/resources/query/ldap/query/GetLdapConfigs.graphql
@@ -16,7 +16,7 @@ query {
         realm
       }
       directorySettings {
-        userNameAttribute
+        loginUserAttribute
         baseUserDn
         baseGroupDn
         groupObjectClass

--- a/ui/src/main/webapp/wizards/ldap/stages/attribute-mapping.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/attribute-mapping.js
@@ -153,13 +153,13 @@ class AttributeMapper extends Component {
   }
 }
 
-const testClaimMappings = (conn, info, userNameAttribute, dn, mapping) => ({
+const testClaimMappings = (conn, info, loginUserAttribute, dn, mapping) => ({
   fetchPolicy: 'network-only',
   query: gql`
     query TestClaimMappings(
       $conn: LdapConnection!,
       $info: BindUserInfo!,
-      $userNameAttribute: LdapAttributeName!,
+      $loginUserAttribute: LdapAttributeName!,
       $dn: DistinguishedName!
       $mapping: [ClaimsMapEntry]!
     ) {
@@ -167,14 +167,14 @@ const testClaimMappings = (conn, info, userNameAttribute, dn, mapping) => ({
         testClaimMappings(
           connection: $conn,
           bindInfo: $info,
-          userNameAttribute: $userNameAttribute,
+          loginUserAttribute: $loginUserAttribute,
           baseUserDn: $dn,
           claimsMapping: $mapping
         )
       }
     }
   `,
-  variables: { conn, info, userNameAttribute, dn, mapping }
+  variables: { conn, info, loginUserAttribute, dn, mapping }
 })
 
 const LdapAttributeMappingStage = (props) => {
@@ -229,7 +229,7 @@ const LdapAttributeMappingStage = (props) => {
     realm: configs.bindRealm
   }
 
-  const userNameAttribute = configs.userNameAttribute
+  const loginUserAttribute = configs.loginUserAttribute
   const dn = configs.baseUserDn
   const mapping = Object.keys(attributeMappings).map((key) => ({ key, value: attributeMappings[key] }))
 
@@ -255,7 +255,7 @@ const LdapAttributeMappingStage = (props) => {
           <Next
             onClick={() => {
               onStartSubmit()
-              client.query(testClaimMappings(conn, info, userNameAttribute, dn, mapping))
+              client.query(testClaimMappings(conn, info, loginUserAttribute, dn, mapping))
                 .then(() => {
                   onEndSubmit()
                   next('confirm')

--- a/ui/src/main/webapp/wizards/ldap/stages/confirm.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/confirm.js
@@ -79,14 +79,14 @@ const ConfirmStage = (props) => {
   }
 
   const settings = {
-    userNameAttribute: configs.userNameAttribute,
+    loginUserAttribute: configs.loginUserAttribute,
+    memberAttributeReferencedInGroup: configs.memberAttributeReferencedInGroup,
     baseUserDn: configs.baseUserDn,
     baseGroupDn: configs.baseGroupDn,
     useCase: configs.ldapUseCase
   }
 
   if (isAttrStore) {
-    settings.memberAttributeReferencedInGroup = configs.memberAttributeReferencedInGroup
     settings.groupObjectClass = configs.groupObjectClass
     settings.groupAttributeHoldingMember = configs.groupAttributeHoldingMember
   }
@@ -121,8 +121,8 @@ const ConfirmStage = (props) => {
               label='Base User DN'
               value={configs.baseUserDn} />
             <Info
-              label='User Name Attribute'
-              value={configs.userNameAttribute} />
+              label='User Login Attribute'
+              value={configs.loginUserAttribute} />
           </Flexbox>
           <Flexbox style={confirmationInfo} flexDirection='column'>
             <Info
@@ -146,7 +146,6 @@ const ConfirmStage = (props) => {
               label='Group Attribute Holding Member References'
               value={configs.groupAttributeHoldingMember} />
             <Info
-              visible={isAttrStore}
               label='Member Attribute Referenced in Groups'
               value={configs.memberAttributeReferencedInGroup} />
           </Flexbox>

--- a/ui/src/main/webapp/wizards/ldap/stages/directory-settings.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/directory-settings.js
@@ -154,17 +154,16 @@ const configInputs = [
     tooltip: 'Distinguished name of the LDAP directory in which users can be found.'
   },
   {
-    key: 'userNameAttribute',
-    optionKey: 'userNameAttributes',
-    label: 'User Name Attribute',
-    tooltip: 'Attribute used to designate the user’s name in LDAP.  Typically uid or cn.'
+    key: 'loginUserAttribute',
+    optionKey: 'loginUserAttributes',
+    label: 'User Login Attribute',
+    tooltip: 'Attribute used to designate the user’s login in LDAP.  Typically uid or cn.'
   },
   {
     key: 'memberAttributeReferencedInGroup',
     optionKey: 'memberAttributesReferencedInGroup',
     label: 'Member Attribute Referenced in Groups',
-    tooltip: 'The attribute of the user entry that, when combined with the Base User DN, forms the reference value, e.g. XXX=jsmith,ou=users,dc=example,dc=com',
-    attrStoreOnly: true
+    tooltip: 'The attribute of the user entry that, when combined with the Base User DN, forms the reference value, e.g. XXX=jsmith,ou=users,dc=example,dc=com'
   },
   {
     key: 'baseGroupDn',
@@ -263,7 +262,7 @@ const DirectorySettings = (props) => {
   }
 
   const settings = {
-    userNameAttribute: configs.userNameAttribute,
+    loginUserAttribute: configs.loginUserAttribute,
     baseUserDn: configs.baseUserDn,
     baseGroupDn: configs.baseGroupDn,
     useCase: configs.ldapUseCase

--- a/ui/src/main/webapp/wizards/ldap/stages/directory-settings.spec.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/directory-settings.spec.js
@@ -30,7 +30,8 @@ describe('<LDAP />', () => {
 
       expect(visible).to.deep.equal([
         'baseUserDn',
-        'userNameAttribute',
+        'loginUserAttribute',
+        'memberAttributeReferencedInGroup',
         'baseGroupDn'
       ])
 
@@ -39,7 +40,6 @@ describe('<LDAP />', () => {
         .map((comp) => comp.prop('id'))
 
       expect(notVisible).to.deep.equal([
-        'memberAttributeReferencedInGroup',
         'groupObjectClass',
         'groupAttributeHoldingMember'
       ])


### PR DESCRIPTION
#### What does this PR do?
Updates the LDAP wizard to be consistent with the Security STS LDAP Login configuration and the Security STS LDAP and Roles Claims Handler configuration.

#### Who is reviewing it 
@coyotesqrl 
@tbatie 
@peterhuffer 
@djblue 

#### How should this be tested? (List steps with links to updated documentation)
- Use the LDAP Wizard to setup various LDAP configurations.
- Verify that the configurations are persisted using the Admin UI.
- Verify that the configurations can be fetched using Graphiql
**graphiql query**
```{
  ldap {
    configs {
      pid
      directorySettings {
        loginUserAttribute
        baseUserDn
        baseGroupDn
        groupObjectClass
        groupAttributeHoldingMember
        memberAttributeReferencedInGroup
        useCase
      }
    }
  }
}
```



#### Any background context you want to provide?

#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
