### PR TITLE
DDF-2773 Changed @VisibleForTestingAnnotation to a suppression

### DIFF
--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapQuery.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapQuery.java
@@ -13,7 +13,6 @@
  */
 package org.codice.ddf.admin.ldap.discover;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
@@ -149,7 +148,8 @@ public class LdapQuery extends BaseFunctionField<MapField.ListImpl> {
         DefaultMessages.CANNOT_CONNECT);
   }
 
-  @VisibleForTesting
+  @SuppressWarnings(
+      "squid:UnusedPrivateMethod" /* For testing purposes only. Groovy can access private methods. */)
   private void setTestingUtils(LdapTestingUtils utils) {
     this.utils = utils;
   }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapRecommendedSettings.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapRecommendedSettings.java
@@ -13,7 +13,6 @@
  */
 package org.codice.ddf.admin.ldap.discover;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
@@ -112,7 +111,8 @@ public class LdapRecommendedSettings extends BaseFunctionField<LdapRecommendedSe
         DefaultMessages.CANNOT_CONNECT);
   }
 
-  @VisibleForTesting
+  @SuppressWarnings(
+      "squid:UnusedPrivateMethod" /* For testing purposes only. Groovy can access private methods. */)
   private void setTestingUtils(LdapTestingUtils utils) {
     this.utils = utils;
   }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestBind.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestBind.java
@@ -18,7 +18,6 @@ import static org.codice.ddf.admin.ldap.fields.connection.LdapBindMethod.DigestM
 import static org.codice.ddf.admin.ldap.fields.connection.LdapEncryptionMethodField.LdapsEncryption.LDAPS;
 import static org.codice.ddf.admin.ldap.fields.connection.LdapEncryptionMethodField.StartTlsEncryption.START_TLS;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
@@ -106,7 +105,8 @@ public class LdapTestBind extends TestFunctionField {
         DefaultMessages.CANNOT_CONNECT);
   }
 
-  @VisibleForTesting
+  @SuppressWarnings(
+      "squid:UnusedPrivateMethod" /* For testing purposes only. Groovy can access private methods. */)
   private void setTestingUtils(LdapTestingUtils utils) {
     this.utils = utils;
   }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestClaimMappings.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestClaimMappings.java
@@ -15,7 +15,6 @@ package org.codice.ddf.admin.ldap.discover;
 
 import static org.codice.ddf.admin.ldap.commons.LdapMessages.userAttributeNotFoundError;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
@@ -192,12 +191,14 @@ public class LdapTestClaimMappings extends TestFunctionField {
         .isEmpty();
   }
 
-  @VisibleForTesting
+  @SuppressWarnings(
+      "squid:UnusedPrivateMethod" /* For testing purposes only. Groovy can access private methods. */)
   private void setTestingUtils(LdapTestingUtils utils) {
     this.utils = utils;
   }
 
-  @VisibleForTesting
+  @SuppressWarnings(
+      "squid:UnusedPrivateMethod" /* For testing purposes only. Groovy can access private methods. */)
   private void setStsServiceProperties(StsServiceProperties stsServiceProperties) {
     this.stsServiceProperties = stsServiceProperties;
   }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestConnection.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestConnection.java
@@ -13,7 +13,6 @@
  */
 package org.codice.ddf.admin.ldap.discover;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
@@ -75,7 +74,8 @@ public class LdapTestConnection extends TestFunctionField {
     return ImmutableSet.of(DefaultMessages.FAILED_TEST_SETUP, DefaultMessages.CANNOT_CONNECT);
   }
 
-  @VisibleForTesting
+  @SuppressWarnings(
+      "squid:UnusedPrivateMethod" /* For testing purposes only. Groovy can access private methods. */)
   private void setTestingUtils(LdapTestingUtils utils) {
     this.utils = utils;
   }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapUserAttributes.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapUserAttributes.java
@@ -13,7 +13,6 @@
  */
 package org.codice.ddf.admin.ldap.discover;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
@@ -113,7 +112,8 @@ public class LdapUserAttributes extends BaseFunctionField<StringField.ListImpl> 
         DefaultMessages.CANNOT_CONNECT);
   }
 
-  @VisibleForTesting
+  @SuppressWarnings(
+      "squid:UnusedPrivateMethod" /* For testing purposes only. Groovy can access private methods. */)
   private void setTestingUtils(LdapTestingUtils utils) {
     this.utils = utils;
   }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/CswSourceUtils.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/CswSourceUtils.java
@@ -21,7 +21,6 @@ import static org.codice.ddf.admin.sources.fields.CswProfile.DDFCswFederatedSour
 import static org.codice.ddf.admin.sources.fields.CswProfile.GmdCswFederatedSource.GMD_CSW_ISO_FEDERATED_SOURCE;
 import static org.codice.ddf.admin.sources.utils.SourceUtilCommons.SOURCES_NAMESPACE_CONTEXT;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
@@ -221,7 +220,8 @@ public class CswSourceUtils {
     return Reports.from(unknownEndpointError(responseField.requestUrlField().getPath()));
   }
 
-  @VisibleForTesting
+  @SuppressWarnings(
+      "squid:UnusedPrivateMethod" /* For testing purposes only. Groovy can access private methods. */)
   private void setRequestUtils(RequestUtils requestUtils) {
     this.requestUtils = requestUtils;
   }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/discover/DiscoverCswSource.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/discover/DiscoverCswSource.java
@@ -13,7 +13,6 @@
  */
 package org.codice.ddf.admin.sources.csw.discover;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.List;
@@ -95,7 +94,8 @@ public class DiscoverCswSource extends BaseFunctionField<CswSourceConfigurationF
     return ImmutableSet.of(DefaultMessages.CANNOT_CONNECT, DefaultMessages.UNKNOWN_ENDPOINT);
   }
 
-  @VisibleForTesting
+  @SuppressWarnings(
+      "squid:UnusedPrivateMethod" /* For testing purposes only. Groovy can access private methods. */)
   private void setCswSourceUtils(CswSourceUtils cswSourceUtils) {
     this.cswSourceUtils = cswSourceUtils;
   }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/OpenSearchSourceUtils.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/OpenSearchSourceUtils.java
@@ -18,7 +18,6 @@ import static org.codice.ddf.admin.common.report.message.DefaultMessages.unknown
 import static org.codice.ddf.admin.common.services.ServiceCommons.FLAG_PASSWORD;
 import static org.codice.ddf.admin.sources.utils.SourceUtilCommons.SOURCES_NAMESPACE_CONTEXT;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
@@ -180,7 +179,8 @@ public class OpenSearchSourceUtils {
     }
   }
 
-  @VisibleForTesting
+  @SuppressWarnings(
+      "squid:UnusedPrivateMethod" /* For testing purposes only. Groovy can access private methods. */)
   private void setRequestUtils(RequestUtils requestUtils) {
     this.requestUtils = requestUtils;
   }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/discover/DiscoverOpenSearchSource.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/discover/DiscoverOpenSearchSource.java
@@ -13,7 +13,6 @@
  */
 package org.codice.ddf.admin.sources.opensearch.discover;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.List;
@@ -98,7 +97,8 @@ public class DiscoverOpenSearchSource
     return ImmutableSet.of(DefaultMessages.CANNOT_CONNECT, DefaultMessages.UNKNOWN_ENDPOINT);
   }
 
-  @VisibleForTesting
+  @SuppressWarnings(
+      "squid:UnusedPrivateMethod" /* For testing purposes only. Groovy can access private methods. */)
   private void setOpenSearchSourceUtils(OpenSearchSourceUtils openSearchSourceUtils) {
     this.openSearchSourceUtils = openSearchSourceUtils;
   }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/WfsSourceUtils.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/WfsSourceUtils.java
@@ -18,7 +18,6 @@ import static org.codice.ddf.admin.common.report.message.DefaultMessages.unknown
 import static org.codice.ddf.admin.common.services.ServiceCommons.FLAG_PASSWORD;
 import static org.codice.ddf.admin.sources.utils.SourceUtilCommons.SOURCES_NAMESPACE_CONTEXT;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
@@ -191,7 +190,8 @@ public class WfsSourceUtils {
     return Reports.from(wfsSourceConfigurationField);
   }
 
-  @VisibleForTesting
+  @SuppressWarnings(
+      "squid:UnusedPrivateMethod" /* For testing purposes only. Groovy can access private methods. */)
   private void setRequestUtils(RequestUtils requestUtils) {
     this.requestUtils = requestUtils;
   }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/discover/DiscoverWfsSource.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/discover/DiscoverWfsSource.java
@@ -13,7 +13,6 @@
  */
 package org.codice.ddf.admin.sources.wfs.discover;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.List;
@@ -95,7 +94,8 @@ public class DiscoverWfsSource extends BaseFunctionField<WfsSourceConfigurationF
     return ImmutableSet.of(DefaultMessages.CANNOT_CONNECT, DefaultMessages.UNKNOWN_ENDPOINT);
   }
 
-  @VisibleForTesting
+  @SuppressWarnings(
+      "squid:UnusedPrivateMethod" /* For testing purposes only. Groovy can access private methods. */)
   private void setWfsSourceUtils(WfsSourceUtils wfsSourceUtils) {
     this.wfsSourceUtils = wfsSourceUtils;
   }


### PR DESCRIPTION
#### What does this PR do?
Changed `@VisibleForTestingAnnotation` to `@SuppressWarnings(
      "squid:UnusedPrivateMethod" /* For testing purposes only. Groovy can access private methods. */)`

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@coyotesqrl @tbatie @peterhuffer 

#### How should this be tested? (List steps with links to updated documentation)
Full build

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
