### PR TITLE
[1.1.x] DDF-2773 Added port validation in the LDAP Wizard before submitting GraphQL query

### DIFF
--- a/ui/src/main/webapp/wizards/ldap/stages/network-settings.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/network-settings.js
@@ -18,6 +18,7 @@ import {
 } from 'admin-wizard/inputs'
 
 import { groupErrors } from './errors'
+import {getFriendlyMessage} from 'graphql-errors'
 
 const testConnect = (conn) => ({
   fetchPolicy: 'network-only',
@@ -50,6 +51,8 @@ const NetworkSettings = (props) => {
     'encryption'
   ], props.errors)
 
+  const isPortInvalid = configs.port === undefined || configs.port < 0 || configs.port > 65535
+
   return (
     <div>
       <Mount
@@ -74,7 +77,7 @@ const NetworkSettings = (props) => {
 
         <Port
           value={configs.port}
-          errorText={errors.port}
+          errorText={isPortInvalid ? getFriendlyMessage('INVALID_PORT_RANGE') : errors.port}
           onEdit={onEdit('port')}
           options={[389, 636]} />
 
@@ -87,7 +90,7 @@ const NetworkSettings = (props) => {
 
         <Navigation>
           <Back onClick={prev} />
-          <Next
+          <Next disabled={isPortInvalid}
             onClick={() => {
               onStartSubmit()
               client.query(testConnect({


### PR DESCRIPTION
#### What does this PR do?
This PR fixes an issue of allowing invalid Port numbers in the LDAP Wizard.

This PR is still a WIP. I need to discuss the solution with SMEs.
#### Who is reviewing it?
@djblue @peterhuffer @garrettfreibott 
#### How should this be tested?
In the LDAP Wizard enter an invalid port number. Confirm that there is an error message.
#### Any background context you want to provide?
The Sources Wizard also does this Port validation on the front end: 
https://github.com/connexta/admin-console/blob/9005fb58bf6b64b90557ab90e0ba21fef1bc2c3e/ui/src/main/webapp/wizards/sources/stages/validation.js#L44-L46 https://github.com/connexta/admin-console/blob/9005fb58bf6b64b90557ab90e0ba21fef1bc2c3e/ui/src/main/webapp/wizards/sources/stages/discovery.js#L68-L73
#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)
#### Screenshots
![image](https://user-images.githubusercontent.com/8041246/34585181-f2ae7210-f15b-11e7-9a18-474cd506b62d.png)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
  