### PR TITLE
Restrict empty field errors to required fields

### DIFF
--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/scalar/StringField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/scalar/StringField.java
@@ -48,7 +48,7 @@ public class StringField extends BaseScalarField<String> {
       return validationMsgs;
     }
 
-    if (getValue() != null && getValue().trim().isEmpty()) {
+    if (isRequired() && getValue() != null && getValue().trim().isEmpty()) {
       validationMsgs.add(emptyFieldError(getPath()));
     }
 

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseFieldTest.groovy
@@ -42,7 +42,19 @@ class BaseFieldTest extends Specification {
         validationMsgs.get(0).getPath() == FIELD_PATH
     }
 
-    def 'Missing required field if value is List and is empty'() {
+    def 'No error when optional value is not provided'() {
+        setup:
+        testField.isRequired(false)
+        testField.setValue(null)
+
+        when:
+        def validationMsgs = testField.validate()
+
+        then:
+        validationMsgs.size() == 0
+    }
+
+    def 'Missing required field if required value is List and is empty'() {
         setup:
         testField.isRequired(true)
         testField.setValue([])
@@ -54,6 +66,18 @@ class BaseFieldTest extends Specification {
         validationMsgs.size() == 1
         validationMsgs.get(0).getCode() == DefaultMessages.MISSING_REQUIRED_FIELD
         validationMsgs.get(0).getPath() == FIELD_PATH
+    }
+
+    def 'No error if optional value is List and is empty'() {
+        setup:
+        testField.isRequired(false)
+        testField.setValue([])
+
+        when:
+        def validationMsgs = testField.validate()
+
+        then:
+        validationMsgs.size() == 0
     }
 
     def 'Returns all the possible error codes correctly'(){

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/scalar/StringFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/scalar/StringFieldTest.groovy
@@ -20,9 +20,10 @@ class StringFieldTest extends Specification {
 
     List<Object> FIELD_PATH = [StringField.DEFAULT_STING_FIELD_NAME]
 
-    def 'Empty field error when empty string provided'() {
+    def 'Empty field error when empty string provided for required field'() {
         setup:
         def stringField = new StringField()
+        stringField.isRequired(true)
         stringField.setValue(value)
         stringField.setPath(FIELD_PATH)
 
@@ -38,9 +39,27 @@ class StringFieldTest extends Specification {
         value << ['', ' ']
     }
 
+    def 'No error when empty string provided for optional field'() {
+        setup:
+        def stringField = new StringField()
+        stringField.isRequired(false)
+        stringField.setValue(value)
+        stringField.setPath(FIELD_PATH)
+
+        when:
+        def validationMsgs = stringField.validate()
+
+        then:
+        validationMsgs.size() == 0
+
+        where:
+        value << ['', ' ']
+    }
+
     def 'Returns all the possible error codes correctly'(){
         setup:
         def emptyStringField = new StringField()
+        emptyStringField.isRequired(true)
         emptyStringField.setValue('')
         emptyStringField.setPath(FIELD_PATH)
 

--- a/ui/src/main/webapp/lib/admin-wizard/inputs.js
+++ b/ui/src/main/webapp/lib/admin-wizard/inputs.js
@@ -34,7 +34,7 @@ const InputView = ({ value = '', label, onEdit, message = {}, tooltip, muiTheme,
         errorStyle={messageStyles[type]}
         value={value}
         floatingLabelText={label}
-        onChange={(e) => onEdit(e.target.value)}
+        onChange={(e) => onEdit(e.target.value.replace(/^\s+/g, ''))}
         {...rest} />
       {(tooltip)
         ? (<IconButton style={{position: 'absolute', right: '10px', bottom: '0px'}}


### PR DESCRIPTION
#### What does this PR do?
Filters out the EMPTY FIELD error for optional string fields in the LDAP wizard. 
Prevents users from entering values with leading whitespace.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@tbatie 
#### How should this be tested? (List steps with links to updated documentation)
On LDAP Bind User Settings page, select `DigestMD5SASL` as Bind User Method and enter any value. Then delete the value and click next. Now select `Simple` as the Bind User Method and click next. The LDAP Directory Structure page should appear.
Unit tests should pass.
#### Any background context you want to provide?
Prior to the change, empty string values would throw `Empty required field.` errors on optional string fields. 

#### Screenshots (if appropriate)

#### Checklist:
- [ x] Update / Add Unit Tests
