### PR TITLE
Prevents requests with empty string from being sent to backend

### DIFF
--- a/ui/src/main/webapp/lib/admin-wizard/enhancers.js
+++ b/ui/src/main/webapp/lib/admin-wizard/enhancers.js
@@ -12,7 +12,9 @@ export const withConfigs = (Component) => ({ state, setState, props }) => {
 
   const onEdit = (id) => {
     if (typeof id === 'string') {
-      return (value) => setState(state.set(id, value))
+      return (value) => {
+        setState(state.set(id, (typeof value === 'string' && value.trim().length === 0) ? undefined : value))
+      }
     } else if (typeof id === 'object') {
       setState(state.merge(id))
     }


### PR DESCRIPTION
#### What does this PR do?
Sets empty string values to null and prevents users from entering values with leading whitespace. 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@tbatie @peterhuffer @blen-desta @garrettfreibott  
#### How should this be tested? (List steps with links to updated documentation)
On LDAP Bind User Settings page, select `DigestMD5SASL` as Bind User Method, attempt to enter empty string value for the realm and click next. `Missing required field.` error should appear instead of `Empty required field`. Now select `Simple` as the Bind User Method and click next. The LDAP Directory Structure page should appear. 
#### Any background context you want to provide?
Prior to this change, empty string values would throw `Empty required field.` errors on optional string fields. This caused a hidden error when clearing out the realm prior to continuing with the `Simple` Bind User Method. 