### PR TITLE
DDF-3584 Updates index.html to use `/webjars` endpoint

### DIFF
--- a/ui/src/main/webapp/lib/static-site-generator/html.js
+++ b/ui/src/main/webapp/lib/static-site-generator/html.js
@@ -37,7 +37,7 @@ const styles = {
 
 export default ({ assets, children }) => {
   const bundles = assets.filter((asset) => asset.match(/bundle.*js$/))
-    .concat('/admin/iframe-resizer/2.6.2/js/iframeResizer.contentWindow.min.js')
+    .concat('/webjars/iframe-resizer/2.6.2/js/iframeResizer.contentWindow.min.js')
   const css = assets.filter((asset) => asset.match(/.*css$/))
 
   return (


### PR DESCRIPTION
#### What does this PR do?

See title.

#### Who is reviewing it?

@tbatie 
@andrewkfiedler 

#### How should this be tested? (List steps with links to updated documentation)

- quick build
- deploy
- ensure ui works in an iframe

#### Any background context you want to provide?

When we [collapse the ui modules](https://github.com/codice/ddf/pull/2911), all the webjars will be served from the `/webjars` path. This fix updates the script to point to the new location.

#### What are the relevant tickets?

[DDF-3584](https://codice.atlassian.net/browse/DDF-3584)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
