### PR TITLE
DDF-2773 Bumped DDF version to 2.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <ddf.version>2.12.0-SNAPSHOT</ddf.version>
+        <ddf.version>2.12.0</ddf.version>
         <ddf.support.version>2.3.9</ddf.support.version>
         <guava.version>18.0</guava.version>
         <karaf.version>4.1.2</karaf.version>


### PR DESCRIPTION
#### What does this PR do?
This PR bumps the DDF version to 2.12.0.
#### Who is reviewing it?
@tbatie @coyotesqrl @peterhuffer 
#### How should this be tested?
Build a release of a project that includes admin-console, and confirm that the Wizards still work.
#### Any background context you want to provide?
The admin-console repo needed to be updated after the feature file rework (a83ee624a13c410bf3ebbea09443885c10e7c9e4), so it should be building with the latest DDF version.
#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)