### PR TITLE
DDF-2773 Add privileged actions to LDAP and Source wizards

### DIFF
--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/persist/CreateLdapConfiguration.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/persist/CreateLdapConfiguration.java
@@ -22,6 +22,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -130,7 +132,10 @@ public class CreateLdapConfiguration extends BaseFunctionField<BooleanField> {
                   ldapClaimsServiceProps));
     }
 
-    OperationReport report = configurator.commit("Creating LDAP configuration.");
+    OperationReport report =
+        AccessController.doPrivileged(
+            (PrivilegedAction<OperationReport>)
+                () -> configurator.commit("Creating LDAP configuration."));
 
     if (report.containsFailedResults()) {
       addErrorMessage(failedPersistError());

--- a/query/sources/common/src/main/java/org/codice/ddf/admin/sources/utils/RequestUtils.java
+++ b/query/sources/common/src/main/java/org/codice/ddf/admin/sources/utils/RequestUtils.java
@@ -18,6 +18,8 @@ import static org.codice.ddf.admin.common.report.message.DefaultMessages.cannotC
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Map;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.core.Response;
@@ -183,7 +185,8 @@ public class RequestUtils {
               ? new SecureCxfClientFactory<>(url, clientServiceClass)
               : new SecureCxfClientFactory<>(url, clientServiceClass, username, password);
 
-      webClient = clientFactory.getWebClient();
+      webClient =
+          AccessController.doPrivileged((PrivilegedAction<WebClient>) clientFactory::getWebClient);
     }
 
     public WebClientBuilder queryParams(Map<String, Object> queryParams) {


### PR DESCRIPTION
#### What does this PR do?
Adds privileged actions to the RequestUtils for the Sources wizard and to the LDAP wizard to be able to read/write the generated LDAP config file.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@tbatie @emmberk @coyotesqrl 

#### How should this be tested? (List steps with links to updated documentation)
With security manager enabled, ensure sources can be discovered and saved, and that LDAP configurations can be configured and saved. Test creating a new policy as well.

#### Any background context you want to provide?
This is a temporary solution until privileged actions are added to the configurator in DDF 2.13.0.

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
