### PR TITLE
DDF-4090 Remove LDAP assumptions and allow multiple hosts in single configuration

### DIFF
--- a/query/security/common/src/main/java/org/codice/ddf/admin/security/common/services/LdapClaimsHandlerServiceProperties.java
+++ b/query/security/common/src/main/java/org/codice/ddf/admin/security/common/services/LdapClaimsHandlerServiceProperties.java
@@ -26,6 +26,8 @@ public class LdapClaimsHandlerServiceProperties {
 
   public static final String URL = "url";
 
+  public static final String LOAD_BALANCING = "loadBalancing";
+
   public static final String START_TLS = "startTls";
 
   public static final String LDAP_BIND_USER_DN = "ldapBindUserDn";

--- a/query/security/common/src/main/java/org/codice/ddf/admin/security/common/services/LdapLoginServiceProperties.java
+++ b/query/security/common/src/main/java/org/codice/ddf/admin/security/common/services/LdapLoginServiceProperties.java
@@ -36,11 +36,15 @@ public class LdapLoginServiceProperties {
 
   public static final String MEMBERSHIP_USER_ATTRIBUTE = "membershipUserAttribute";
 
+  public static final String MEMBER_NAME_ATTRIBUTE = "memberNameAttribute";
+
   public static final String USER_BASE_DN = "userBaseDn";
 
   public static final String GROUP_BASE_DN = "groupBaseDn";
 
   public static final String LDAP_URL = "ldapUrl";
+
+  public static final String LDAP_LOAD_BALANCING = "ldapLoadBalancing";
 
   public static final String START_TLS = "startTls";
   // ---

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/commons/LdapServiceCommons.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/commons/LdapServiceCommons.java
@@ -87,8 +87,8 @@ public class LdapServiceCommons {
     Map<String, Object> props = new HashMap<>();
 
     if (config != null) {
-      boolean startTls = isStartTls(config.connectionField());
-      props.put(LdapClaimsHandlerServiceProperties.URL, getLdapUrls(config.connectionField()));
+      boolean startTls = isStartTls(config.connectionsField());
+      props.put(LdapClaimsHandlerServiceProperties.URL, config.connectionsField().getLdapUrls());
       props.put(
           LdapClaimsHandlerServiceProperties.LOAD_BALANCING,
           config.loadBalancingField().getValue());
@@ -126,9 +126,10 @@ public class LdapServiceCommons {
     Map<String, Object> ldapStsConfig = new HashMap<>();
 
     if (config != null) {
-      boolean startTls = isStartTls(config.connectionField());
+      boolean startTls = isStartTls(config.connectionsField());
 
-      ldapStsConfig.put(LdapLoginServiceProperties.LDAP_URL, getLdapUrls(config.connectionField()));
+      ldapStsConfig.put(
+          LdapLoginServiceProperties.LDAP_URL, config.connectionsField().getLdapUrls());
       ldapStsConfig.put(
           LdapLoginServiceProperties.LDAP_LOAD_BALANCING, config.loadBalancingField().getValue());
       ldapStsConfig.put(LdapLoginServiceProperties.START_TLS, Boolean.toString(startTls));
@@ -163,18 +164,9 @@ public class LdapServiceCommons {
     return ldapStsConfig;
   }
 
-  private String[] getLdapUrls(ListField<LdapConnectionField> connections) {
-    return connections
-        .getList()
-        .stream()
-        .map(LdapConnectionField::getLdapUrl)
-        .collect(Collectors.toList())
-        .toArray(new String[] {});
-  }
-
   private LdapConfigurationField ldapClaimsHandlerServiceToLdapConfig(Map<String, Object> props) {
-    ListField<LdapConnectionField> connection =
-        getLdapConnectionField(
+    LdapConnectionField.ListImpl connections =
+        getLdapConnectionsField(
             props,
             LdapClaimsHandlerServiceProperties.URL,
             LdapClaimsHandlerServiceProperties.START_TLS);
@@ -211,7 +203,7 @@ public class LdapServiceCommons {
     }
 
     return new LdapConfigurationField()
-        .connection(connection)
+        .connections(connections)
         .loadBalancing(loadBalancing)
         .bindUserInfo(bindUserInfo)
         .settings(settings)
@@ -223,8 +215,8 @@ public class LdapServiceCommons {
   }
 
   private LdapConfigurationField ldapLoginServiceToLdapConfiguration(Map<String, Object> props) {
-    ListField<LdapConnectionField> connection =
-        getLdapConnectionField(
+    LdapConnectionField.ListImpl connections =
+        getLdapConnectionsField(
             props, LdapLoginServiceProperties.LDAP_URL, LdapLoginServiceProperties.START_TLS);
 
     LdapLoadBalancingField loadBalancing = new LdapLoadBalancingField();
@@ -253,16 +245,16 @@ public class LdapServiceCommons {
             .useCase(AUTHENTICATION);
 
     return new LdapConfigurationField()
-        .connection(connection)
+        .connections(connections)
         .loadBalancing(loadBalancing)
         .bindUserInfo(bindUserInfo)
         .settings(settings)
         .pid(mapValue(props, SERVICE_PID_KEY));
   }
 
-  private ListField<LdapConnectionField> getLdapConnectionField(
+  private LdapConnectionField.ListImpl getLdapConnectionsField(
       Map<String, Object> props, String ldapUrlKey, String startTlsKey) {
-    ListField<LdapConnectionField> connection = new LdapConnectionField.ListImpl();
+    LdapConnectionField.ListImpl connection = new LdapConnectionField.ListImpl();
 
     Boolean isStartTls = (Boolean) props.get(startTlsKey);
 

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/config/LdapConfigurationField.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/config/LdapConfigurationField.java
@@ -25,6 +25,7 @@ import org.codice.ddf.admin.common.fields.base.BaseObjectField;
 import org.codice.ddf.admin.common.fields.common.PidField;
 import org.codice.ddf.admin.ldap.fields.connection.LdapBindUserInfo;
 import org.codice.ddf.admin.ldap.fields.connection.LdapConnectionField;
+import org.codice.ddf.admin.ldap.fields.connection.LdapLoadBalancingField;
 import org.codice.ddf.admin.security.common.fields.wcpm.ClaimsMapEntry;
 
 public class LdapConfigurationField extends BaseObjectField {
@@ -39,7 +40,9 @@ public class LdapConfigurationField extends BaseObjectField {
 
   private PidField pid;
 
-  private LdapConnectionField connection;
+  private ListField<LdapConnectionField> connection;
+
+  private LdapLoadBalancingField loadBalancing;
 
   private LdapBindUserInfo bindUserInfo;
 
@@ -50,15 +53,25 @@ public class LdapConfigurationField extends BaseObjectField {
   public LdapConfigurationField() {
     super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
     pid = new PidField();
-    connection = new LdapConnectionField();
+    connection = new LdapConnectionField.ListImpl();
+    loadBalancing = new LdapLoadBalancingField();
     bindUserInfo = new LdapBindUserInfo();
     settings = new LdapDirectorySettingsField();
     claimMappings = new ClaimsMapEntry.ListImpl();
   }
 
   // Field getters
-  public LdapConnectionField connectionField() {
+  public ListField<LdapConnectionField> connectionField() {
     return connection;
+  }
+
+  public LdapConfigurationField connectionField(ListField<LdapConnectionField> entries) {
+    connection = entries;
+    return this;
+  }
+
+  public LdapLoadBalancingField loadBalancingField() {
+    return loadBalancing;
   }
 
   public LdapBindUserInfo bindUserInfoField() {
@@ -100,8 +113,18 @@ public class LdapConfigurationField extends BaseObjectField {
     return this;
   }
 
-  public LdapConfigurationField connection(LdapConnectionField connection) {
+  public LdapConfigurationField connection(List<LdapConnectionField> connection) {
+    this.connection.setValue(connection);
+    return this;
+  }
+
+  public LdapConfigurationField connection(ListField<LdapConnectionField> connection) {
     this.connection.setValue(connection.getValue());
+    return this;
+  }
+
+  public LdapConfigurationField loadBalancing(LdapLoadBalancingField loadBalancing) {
+    this.loadBalancing.setValue(loadBalancing.getValue());
     return this;
   }
 
@@ -132,11 +155,10 @@ public class LdapConfigurationField extends BaseObjectField {
 
   @Override
   public List<Field> getFields() {
-    return ImmutableList.of(pid, connection, bindUserInfo, settings, claimMappings);
+    return ImmutableList.of(pid, connection, loadBalancing, bindUserInfo, settings, claimMappings);
   }
 
   public LdapConfigurationField useDefaultRequired() {
-    connection.useDefaultRequired();
     bindUserInfo.useDefaultRequired();
     settings.useDefaultRequiredForAuthentication();
     isRequired(true);

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/config/LdapConfigurationField.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/config/LdapConfigurationField.java
@@ -40,7 +40,7 @@ public class LdapConfigurationField extends BaseObjectField {
 
   private PidField pid;
 
-  private ListField<LdapConnectionField> connection;
+  private LdapConnectionField.ListImpl connections;
 
   private LdapLoadBalancingField loadBalancing;
 
@@ -53,7 +53,7 @@ public class LdapConfigurationField extends BaseObjectField {
   public LdapConfigurationField() {
     super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
     pid = new PidField();
-    connection = new LdapConnectionField.ListImpl();
+    connections = new LdapConnectionField.ListImpl();
     loadBalancing = new LdapLoadBalancingField();
     bindUserInfo = new LdapBindUserInfo();
     settings = new LdapDirectorySettingsField();
@@ -61,12 +61,12 @@ public class LdapConfigurationField extends BaseObjectField {
   }
 
   // Field getters
-  public ListField<LdapConnectionField> connectionField() {
-    return connection;
+  public LdapConnectionField.ListImpl connectionsField() {
+    return connections;
   }
 
-  public LdapConfigurationField connectionField(ListField<LdapConnectionField> entries) {
-    connection = entries;
+  public LdapConfigurationField connectionsField(LdapConnectionField.ListImpl entries) {
+    connections = entries;
     return this;
   }
 
@@ -113,13 +113,13 @@ public class LdapConfigurationField extends BaseObjectField {
     return this;
   }
 
-  public LdapConfigurationField connection(List<LdapConnectionField> connection) {
-    this.connection.setValue(connection);
+  public LdapConfigurationField connections(List<LdapConnectionField> connections) {
+    this.connections.setValue(connections);
     return this;
   }
 
-  public LdapConfigurationField connection(ListField<LdapConnectionField> connection) {
-    this.connection.setValue(connection.getValue());
+  public LdapConfigurationField connections(LdapConnectionField.ListImpl connections) {
+    this.connections.setValue(connections.getValue());
     return this;
   }
 
@@ -155,10 +155,11 @@ public class LdapConfigurationField extends BaseObjectField {
 
   @Override
   public List<Field> getFields() {
-    return ImmutableList.of(pid, connection, loadBalancing, bindUserInfo, settings, claimMappings);
+    return ImmutableList.of(pid, connections, loadBalancing, bindUserInfo, settings, claimMappings);
   }
 
   public LdapConfigurationField useDefaultRequired() {
+    connections.useDefaultRequired();
     bindUserInfo.useDefaultRequired();
     settings.useDefaultRequiredForAuthentication();
     isRequired(true);

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/connection/LdapConnectionField.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/connection/LdapConnectionField.java
@@ -108,7 +108,7 @@ public class LdapConnectionField extends BaseObjectField {
 
   public static class ListImpl extends BaseListField<LdapConnectionField> {
 
-    public static final String DEFAULT_FIELD_NAME = "connection";
+    public static final String DEFAULT_FIELD_NAME = "connections";
 
     private Callable<LdapConnectionField> newConnection;
 
@@ -135,15 +135,16 @@ public class LdapConnectionField extends BaseObjectField {
             entry.useDefaultRequired();
             return entry;
           };
-
+      isRequired(true);
       return this;
     }
 
-    public List<String> getLdapUrls() {
+    public String[] getLdapUrls() {
       return this.elements
           .stream()
           .map(LdapConnectionField::getLdapUrl)
-          .collect(Collectors.toList());
+          .collect(Collectors.toList())
+          .toArray(new String[] {});
     }
   }
 }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/connection/LdapConnectionField.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/connection/LdapConnectionField.java
@@ -140,7 +140,10 @@ public class LdapConnectionField extends BaseObjectField {
     }
 
     public List<String> getLdapUrls() {
-      return this.elements.stream().map(conn -> conn.getLdapUrl()).collect(Collectors.toList());
+      return this.elements
+          .stream()
+          .map(LdapConnectionField::getLdapUrl)
+          .collect(Collectors.toList());
     }
   }
 }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/connection/LdapLoadBalancingField.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/connection/LdapLoadBalancingField.java
@@ -39,7 +39,7 @@ public class LdapLoadBalancingField extends BaseEnumField<String> {
   }
 
   public static final class RoundRobinEnumValue implements EnumValue<String> {
-    public static final String ROUND_ROBIN = "round_robin";
+    public static final String ROUND_ROBIN = "roundRobin";
 
     public static final String DESCRIPTION =
         "The configured LDAP server cluster will be treated as an all active cluster and connections to the cluster will be made in a round-robin order.";

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/connection/LdapLoadBalancingField.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/connection/LdapLoadBalancingField.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.admin.ldap.fields.connection;
+
+import com.google.common.collect.ImmutableList;
+import org.codice.ddf.admin.api.fields.EnumValue;
+import org.codice.ddf.admin.common.fields.base.BaseEnumField;
+
+public class LdapLoadBalancingField extends BaseEnumField<String> {
+  public static final String DEFAULT_FIELD_NAME = "ldapLoadBalancing";
+
+  public static final String FIELD_TYPE_NAME = "LdapLoadBalancing";
+
+  public static final String DESCRIPTION =
+      "The load balancing algorithm to use for LDAP connections";
+
+  public LdapLoadBalancingField() {
+    this(new RoundRobinEnumValue());
+  }
+
+  private LdapLoadBalancingField(EnumValue<String> loadBalancing) {
+    super(
+        DEFAULT_FIELD_NAME,
+        FIELD_TYPE_NAME,
+        DESCRIPTION,
+        ImmutableList.of(new RoundRobinEnumValue(), new FailoverEnumValue()),
+        loadBalancing);
+  }
+
+  public static final class RoundRobinEnumValue implements EnumValue<String> {
+    public static final String ROUND_ROBIN = "round_robin";
+
+    public static final String DESCRIPTION =
+        "The configured LDAP server cluster will be treated as an all active cluster and connections to the cluster will be made in a round-robin order.";
+
+    @Override
+    public String getEnumTitle() {
+      return ROUND_ROBIN;
+    }
+
+    @Override
+    public String getDescription() {
+      return DESCRIPTION;
+    }
+
+    @Override
+    public String getValue() {
+      return ROUND_ROBIN;
+    }
+  }
+
+  public static final class FailoverEnumValue implements EnumValue<String> {
+    public static final String FAILOVER = "failover";
+
+    public static final String DESCRIPTION =
+        "The configured LDAP server cluster will be treated as a failover cluster and only the primary (first) server will be connected to unless the connections to it fail at which point the next server in the list will be used.";
+
+    @Override
+    public String getEnumTitle() {
+      return FAILOVER;
+    }
+
+    @Override
+    public String getDescription() {
+      return DESCRIPTION;
+    }
+
+    @Override
+    public String getValue() {
+      return FAILOVER;
+    }
+  }
+}

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/persist/CreateLdapConfiguration.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/persist/CreateLdapConfiguration.java
@@ -146,6 +146,7 @@ public class CreateLdapConfiguration extends BaseFunctionField<BooleanField> {
 
   @Override
   public void validate() {
+    config.connectionField().isRequired(true);
     String useCase = config.settingsField().useCase();
     if (useCase != null
         && (useCase.equals(ATTRIBUTE_STORE)

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/persist/CreateLdapConfiguration.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/persist/CreateLdapConfiguration.java
@@ -146,13 +146,15 @@ public class CreateLdapConfiguration extends BaseFunctionField<BooleanField> {
 
   @Override
   public void validate() {
-    config.connectionField().isRequired(true);
     String useCase = config.settingsField().useCase();
     if (useCase != null
         && (useCase.equals(ATTRIBUTE_STORE)
             || useCase.equals(AUTHENTICATION_AND_ATTRIBUTE_STORE))) {
       config.settingsField().useDefaultRequiredForAttributeStore();
       config.claimMappingsField().isRequired(true);
+    }
+    if (config.connectionsField().getList().size() > 1) {
+      config.loadBalancingField().isRequired(true);
     }
 
     super.validate();

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/CreateLdapConfigurationSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/CreateLdapConfigurationSpec.groovy
@@ -40,9 +40,7 @@ class CreateLdapConfigurationSpec extends Specification {
     def setup() {
         // Initialize bad paths
         baseMsg = [CreateLdapConfiguration.FIELD_NAME, LdapConfigurationField.DEFAULT_FIELD_NAME]
-        authBadPaths = [missingHostPath    : baseMsg + [LdapConnectionField.DEFAULT_FIELD_NAME, HostnameField.DEFAULT_FIELD_NAME],
-                        missingPortPath    : baseMsg + [LdapConnectionField.DEFAULT_FIELD_NAME, PortField.DEFAULT_FIELD_NAME],
-                        missingEncryptPath : baseMsg + [LdapConnectionField.DEFAULT_FIELD_NAME, LdapEncryptionMethodField.DEFAULT_FIELD_NAME],
+        authBadPaths = [missingConnectionPath    : baseMsg + [LdapConnectionField.DEFAULT_FIELD_NAME],
                         missingUsernamePath: baseMsg + [LdapBindUserInfo.DEFAULT_FIELD_NAME, CredentialsField.DEFAULT_FIELD_NAME, CredentialsField.USERNAME_FIELD_NAME],
                         missingUserpasswordPath: baseMsg + [LdapBindUserInfo.DEFAULT_FIELD_NAME, CredentialsField.DEFAULT_FIELD_NAME, CredentialsField.PASSWORD_FIELD_NAME],
                         missingBindMethodPath  : baseMsg + [LdapBindUserInfo.DEFAULT_FIELD_NAME, LdapBindMethod.DEFAULT_FIELD_NAME],
@@ -75,14 +73,12 @@ class CreateLdapConfigurationSpec extends Specification {
         FunctionReport report = createConfigFunc.execute(null, FUNCTION_PATH)
 
         then:
-        report.getErrorMessages().size() == 10
+        report.getErrorMessages().size() == 8
         report.getErrorMessages().count {
             it.getCode() == DefaultMessages.MISSING_REQUIRED_FIELD
-        } == 10
+        } == 8
 
-        report.getErrorMessages()*.getPath() as Set == [authBadPaths.missingHostPath,
-                                                authBadPaths.missingPortPath,
-                                                authBadPaths.missingEncryptPath,
+        report.getErrorMessages()*.getPath() as Set == [authBadPaths.missingConnectionPath,
                                                 authBadPaths.missingUsernamePath,
                                                 authBadPaths.missingUserpasswordPath,
                                                 authBadPaths.missingBindMethodPath,
@@ -105,9 +101,7 @@ class CreateLdapConfigurationSpec extends Specification {
         FunctionReport report = createConfigFunc.execute(args, FUNCTION_PATH)
 
         then:
-        report.getErrorMessages()*.getPath() as Set == [authBadPaths.missingHostPath,
-                                                authBadPaths.missingPortPath,
-                                                authBadPaths.missingEncryptPath,
+        report.getErrorMessages()*.getPath() as Set == [authBadPaths.missingConnectionPath,
                                                 authBadPaths.missingUsernamePath,
                                                 authBadPaths.missingUserpasswordPath,
                                                 authBadPaths.missingBindMethodPath,
@@ -120,9 +114,9 @@ class CreateLdapConfigurationSpec extends Specification {
                                                 attributeStoreBadPaths.missingClaimsMappingPath
 
         ] as Set
-        report.getErrorMessages().size() == 13
+        report.getErrorMessages().size() == 11
         report.getErrorMessages().count {
             it.getCode() == DefaultMessages.MISSING_REQUIRED_FIELD
-        } == 13
+        } == 11
     }
 }

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/CreateLdapConfigurationSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/CreateLdapConfigurationSpec.groovy
@@ -40,7 +40,7 @@ class CreateLdapConfigurationSpec extends Specification {
     def setup() {
         // Initialize bad paths
         baseMsg = [CreateLdapConfiguration.FIELD_NAME, LdapConfigurationField.DEFAULT_FIELD_NAME]
-        authBadPaths = [missingConnectionPath    : baseMsg + [LdapConnectionField.DEFAULT_FIELD_NAME],
+        authBadPaths = [missingConnectionPath    : baseMsg + [LdapConnectionField.ListImpl.DEFAULT_FIELD_NAME],
                         missingUsernamePath: baseMsg + [LdapBindUserInfo.DEFAULT_FIELD_NAME, CredentialsField.DEFAULT_FIELD_NAME, CredentialsField.USERNAME_FIELD_NAME],
                         missingUserpasswordPath: baseMsg + [LdapBindUserInfo.DEFAULT_FIELD_NAME, CredentialsField.DEFAULT_FIELD_NAME, CredentialsField.PASSWORD_FIELD_NAME],
                         missingBindMethodPath  : baseMsg + [LdapBindUserInfo.DEFAULT_FIELD_NAME, LdapBindMethod.DEFAULT_FIELD_NAME],

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/GetLdapConfigurationsSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/GetLdapConfigurationsSpec.groovy
@@ -66,7 +66,7 @@ class GetLdapConfigurationsSpec extends Specification {
     private getTestLdapServiceProps() {
         def config = new LdapConfigurationField()
                 .bindUserInfo(LdapTestingCommons.simpleBindInfo().password('notTheFlagPassword'))
-                .connection(LdapTestingCommons.noEncryptionLdapConnectionInfo())
+                .connection(LdapTestingCommons.noEncryptionLdapConnectionList())
 
         return [
                 'somePid': new LdapServiceCommons(configuratorSuite).ldapConfigToLdapClaimsHandlerService(config, "/some/path")

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/GetLdapConfigurationsSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/GetLdapConfigurationsSpec.groovy
@@ -66,7 +66,7 @@ class GetLdapConfigurationsSpec extends Specification {
     private getTestLdapServiceProps() {
         def config = new LdapConfigurationField()
                 .bindUserInfo(LdapTestingCommons.simpleBindInfo().password('notTheFlagPassword'))
-                .connection(LdapTestingCommons.noEncryptionLdapConnectionList())
+                .connections(LdapTestingCommons.noEncryptionLdapConnectionList())
 
         return [
                 'somePid': new LdapServiceCommons(configuratorSuite).ldapConfigToLdapClaimsHandlerService(config, "/some/path")

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapRecommendedSettingsSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapRecommendedSettingsSpec.groovy
@@ -144,7 +144,7 @@ class LdapRecommendedSettingsSpec extends Specification {
         recSettings.userDnsField().value.size() == 1
         recSettings.userDnsField().value.first() == 'ou=users,dc=example,dc=com'
 
-        recSettings.groupDnsField().value.size() == 2
+        recSettings.groupDnsField().value.size() == 1
         recSettings.groupDnsField().value.any {
             it == 'ou=groups,dc=example,dc=com'
         }
@@ -154,13 +154,13 @@ class LdapRecommendedSettingsSpec extends Specification {
 
         recSettings.groupObjectClassesField().value.collect {
             it.toLowerCase()
-        } as Set == ['group', 'groupofnames', 'posixgroup'] as Set
+        } as Set == ['groupofnames'] as Set
 
         recSettings.groupAttributesHoldingMemberField().value.collect {
             it.toLowerCase()
-        } as Set == ['member', 'uniquemember', 'memberuid'] as Set
+        } as Set == ['member'] as Set
 
-        recSettings.memberAttributesReferencedInGroupField().value == ['uid']
+        recSettings.memberAttributesReferencedInGroupField().value == ['uid', 'cn']
 
         recSettings.queryBasesField().value == [TestLdapServer.getBaseDistinguishedName()]
 

--- a/query/security/ldap/src/test/java/org/codice/ddf/admin/ldap/LdapTestingCommons.java
+++ b/query/security/ldap/src/test/java/org/codice/ddf/admin/ldap/LdapTestingCommons.java
@@ -15,6 +15,7 @@ package org.codice.ddf.admin.ldap;
 
 import java.io.IOException;
 import java.util.Properties;
+import org.codice.ddf.admin.api.fields.ListField;
 import org.codice.ddf.admin.ldap.fields.config.LdapDirectorySettingsField;
 import org.codice.ddf.admin.ldap.fields.connection.LdapBindMethod.SimpleEnumValue;
 import org.codice.ddf.admin.ldap.fields.connection.LdapBindUserInfo;
@@ -39,6 +40,12 @@ public class LdapTestingCommons {
         .hostname(TestLdapServer.getHostname())
         .port(TestLdapServer.getLdapPort())
         .encryptionMethod(LdapEncryptionMethodField.NoEncryption.NONE);
+  }
+
+  public static ListField<LdapConnectionField> noEncryptionLdapConnectionList() {
+    ListField<LdapConnectionField> connections = new LdapConnectionField.ListImpl();
+    connections.add(noEncryptionLdapConnectionInfo());
+    return connections;
   }
 
   public static LdapBindUserInfo simpleBindInfo() {

--- a/query/security/ldap/src/test/java/org/codice/ddf/admin/ldap/LdapTestingCommons.java
+++ b/query/security/ldap/src/test/java/org/codice/ddf/admin/ldap/LdapTestingCommons.java
@@ -15,7 +15,6 @@ package org.codice.ddf.admin.ldap;
 
 import java.io.IOException;
 import java.util.Properties;
-import org.codice.ddf.admin.api.fields.ListField;
 import org.codice.ddf.admin.ldap.fields.config.LdapDirectorySettingsField;
 import org.codice.ddf.admin.ldap.fields.connection.LdapBindMethod.SimpleEnumValue;
 import org.codice.ddf.admin.ldap.fields.connection.LdapBindUserInfo;
@@ -42,8 +41,8 @@ public class LdapTestingCommons {
         .encryptionMethod(LdapEncryptionMethodField.NoEncryption.NONE);
   }
 
-  public static ListField<LdapConnectionField> noEncryptionLdapConnectionList() {
-    ListField<LdapConnectionField> connections = new LdapConnectionField.ListImpl();
+  public static LdapConnectionField.ListImpl noEncryptionLdapConnectionList() {
+    LdapConnectionField.ListImpl connections = new LdapConnectionField.ListImpl();
     connections.add(noEncryptionLdapConnectionInfo());
     return connections;
   }

--- a/tests/itests/src/test/java/org/codice/ddf/admin/query/AdminSecurityIT.java
+++ b/tests/itests/src/test/java/org/codice/ddf/admin/query/AdminSecurityIT.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.codice.ddf.admin.api.fields.EnumValue;
+import org.codice.ddf.admin.api.fields.ListField;
 import org.codice.ddf.admin.common.fields.common.CredentialsField;
 import org.codice.ddf.admin.comp.test.AbstractComponentTest;
 import org.codice.ddf.admin.comp.test.AdminAppFeatureFile;
@@ -257,6 +258,9 @@ public class AdminSecurityIT extends AbstractComponentTest {
             .hostname("testHostName")
             .port(666);
 
+    ListField<LdapConnectionField> connections = new LdapConnectionField.ListImpl();
+    connections.add(connection);
+
     LdapDirectorySettingsField dirSettings =
         new LdapDirectorySettingsField()
             .baseUserDn(TEST_DN)
@@ -276,6 +280,6 @@ public class AdminSecurityIT extends AbstractComponentTest {
               .add(new ClaimsMapEntry().key(TEST_CLAIM_KEY).value(TEST_CLAIM_VALUE)));
     }
 
-    return newConfig.connection(connection).bindUserInfo(bindUserInfo).settings(dirSettings);
+    return newConfig.connection(connections).bindUserInfo(bindUserInfo).settings(dirSettings);
   }
 }

--- a/tests/itests/src/test/java/org/codice/ddf/admin/query/AdminSecurityIT.java
+++ b/tests/itests/src/test/java/org/codice/ddf/admin/query/AdminSecurityIT.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.codice.ddf.admin.api.fields.EnumValue;
-import org.codice.ddf.admin.api.fields.ListField;
 import org.codice.ddf.admin.common.fields.common.CredentialsField;
 import org.codice.ddf.admin.comp.test.AbstractComponentTest;
 import org.codice.ddf.admin.comp.test.AdminAppFeatureFile;
@@ -258,7 +257,7 @@ public class AdminSecurityIT extends AbstractComponentTest {
             .hostname("testHostName")
             .port(666);
 
-    ListField<LdapConnectionField> connections = new LdapConnectionField.ListImpl();
+    LdapConnectionField.ListImpl connections = new LdapConnectionField.ListImpl();
     connections.add(connection);
 
     LdapDirectorySettingsField dirSettings =
@@ -280,6 +279,6 @@ public class AdminSecurityIT extends AbstractComponentTest {
               .add(new ClaimsMapEntry().key(TEST_CLAIM_KEY).value(TEST_CLAIM_VALUE)));
     }
 
-    return newConfig.connection(connections).bindUserInfo(bindUserInfo).settings(dirSettings);
+    return newConfig.connections(connections).bindUserInfo(bindUserInfo).settings(dirSettings);
   }
 }

--- a/tests/itests/src/test/java/org/codice/ddf/admin/query/request/LdapRequestHelper.java
+++ b/tests/itests/src/test/java/org/codice/ddf/admin/query/request/LdapRequestHelper.java
@@ -105,7 +105,7 @@ public class LdapRequestHelper {
           requestFactory
               .createRequest()
               .usingMutation("CreateLdapConfig.graphql")
-              .addArgument("connection", config.connectionField().getValue())
+              .addArgument("connection", config.connectionsField().getValue())
               .addArgument("bindInfo", config.bindUserInfoField().getValue())
               .addArgument("settings", config.settingsField().getValue())
               .addArgument("claimsMapping", config.claimMappingsField().getValue())

--- a/ui/src/main/webapp/wizards/ldap/stages/attribute-mapping.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/attribute-mapping.js
@@ -222,12 +222,9 @@ class LdapAttributeMappingStage extends Component {
       return !before.includes(err.message)
     })
 
-    const connKey = Object.keys(configs.connectionInfo)[0]
-    const connInfo = configs.connectionInfo[connKey]
-
     const conn = {
-      hostname: connInfo[0],
-      port: connInfo[1],
+      hostname: configs.connectionList[0].hostname,
+      port: configs.connectionList[0].port,
       encryption: configs.encryption
     }
 
@@ -322,8 +319,8 @@ export default graphql(gql`
     fetchPolicy: 'network-only',
     variables: {
       conn: {
-        hostname: configs.connectionInfo[Object.keys(configs.connectionInfo)[0]][0],
-        port: configs.connectionInfo[Object.keys(configs.connectionInfo)[0]][1],
+        hostname: configs.connectionList[0].hostname,
+        port: configs.connectionList[0].port,
         encryption: configs.encryption
       },
       info: {

--- a/ui/src/main/webapp/wizards/ldap/stages/attribute-mapping.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/attribute-mapping.js
@@ -222,9 +222,12 @@ class LdapAttributeMappingStage extends Component {
       return !before.includes(err.message)
     })
 
+    const connKey = Object.keys(configs.connectionInfo)[0]
+    const connInfo = configs.connectionInfo[connKey]
+
     const conn = {
-      hostname: configs.hostname,
-      port: configs.port,
+      hostname: connInfo[0],
+      port: connInfo[1],
       encryption: configs.encryption
     }
 
@@ -319,8 +322,8 @@ export default graphql(gql`
     fetchPolicy: 'network-only',
     variables: {
       conn: {
-        hostname: configs.hostname,
-        port: configs.port,
+        hostname: configs.connectionInfo[Object.keys(configs.connectionInfo)[0]][0],
+        port: configs.connectionInfo[Object.keys(configs.connectionInfo)[0]][1],
         encryption: configs.encryption
       },
       info: {

--- a/ui/src/main/webapp/wizards/ldap/stages/bind-settings.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/bind-settings.js
@@ -119,9 +119,11 @@ const BindSettings = (props) => {
           <Next
             onClick={() => {
               onStartSubmit()
+              var key = Object.keys(configs.connectionInfo)[0]
+              var connInfo = configs.connectionInfo[key]
               client.query(testBind({
-                hostname: configs.hostname,
-                port: configs.port,
+                hostname: connInfo[0],
+                port: connInfo[1],
                 encryption: configs.encryption
               }, {
                 creds: {

--- a/ui/src/main/webapp/wizards/ldap/stages/bind-settings.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/bind-settings.js
@@ -119,11 +119,9 @@ const BindSettings = (props) => {
           <Next
             onClick={() => {
               onStartSubmit()
-              var key = Object.keys(configs.connectionInfo)[0]
-              var connInfo = configs.connectionInfo[key]
               client.query(testBind({
-                hostname: connInfo[0],
-                port: connInfo[1],
+                hostname: configs.connectionList[0].hostname,
+                port: configs.connectionList[0].port,
                 encryption: configs.encryption
               }, {
                 creds: {

--- a/ui/src/main/webapp/wizards/ldap/stages/confirm.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/confirm.js
@@ -89,9 +89,9 @@ const ConfirmStage = (props) => {
 
   const mapping = Object.keys(configs.attributeMappings || {}).map((key) => ({ key, value: configs.attributeMappings[key] }))
 
-  const hosts = Object.keys(configs.connectionInfo || {}).map((key, i) => ({
-    hostname: configs.connectionInfo[key][0],
-    port: configs.connectionInfo[key][1],
+  const hosts = configs.connectionList.map((connection, i) => ({
+    hostname: connection.hostname,
+    port: connection.port,
     encryption: configs.encryption
   }))
 

--- a/ui/src/main/webapp/wizards/ldap/stages/confirm.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/confirm.js
@@ -35,7 +35,7 @@ const createLdapConfig = (hosts, ldapLoadBalancing, info, settings, mapping) => 
       $mapping: [ClaimsMapEntry]
     ) {
       createLdapConfig(config: {
-        connection: $hosts,
+        connections: $hosts,
         ldapLoadBalancing: $ldapLoadBalancing,
         bindInfo: $info,
         directorySettings: $settings,
@@ -79,12 +79,12 @@ const ConfirmStage = (props) => {
     memberAttributeReferencedInGroup: configs.memberAttributeReferencedInGroup,
     baseUserDn: configs.baseUserDn,
     baseGroupDn: configs.baseGroupDn,
-    useCase: configs.ldapUseCase
+    useCase: configs.ldapUseCase,
+    groupAttributeHoldingMember: configs.groupAttributeHoldingMember
   }
 
   if (isAttrStore) {
     settings.groupObjectClass = configs.groupObjectClass
-    settings.groupAttributeHoldingMember = configs.groupAttributeHoldingMember
   }
 
   const mapping = Object.keys(configs.attributeMappings || {}).map((key) => ({ key, value: configs.attributeMappings[key] }))
@@ -146,7 +146,6 @@ const ConfirmStage = (props) => {
               label='LDAP Group Object Class'
               value={configs.groupObjectClass} />
             <Info
-              visible={isAttrStore}
               label='Group Attribute Holding Member References'
               value={configs.groupAttributeHoldingMember} />
             <Info

--- a/ui/src/main/webapp/wizards/ldap/stages/directory-settings.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/directory-settings.js
@@ -182,8 +182,7 @@ const configInputs = [
     key: 'groupAttributeHoldingMember',
     optionKey: 'groupAttributesHoldingMember',
     label: 'Group Attribute Holding Member References',
-    tooltip: 'Multivalued-attribute on the group entry that holds references to users.',
-    attrStoreOnly: true
+    tooltip: 'Multivalued-attribute on the group entry that holds references to users.'
   },
   {
     key: 'queryBase',
@@ -268,13 +267,13 @@ const DirectorySettings = (props) => {
     loginUserAttribute: configs.loginUserAttribute,
     baseUserDn: configs.baseUserDn,
     baseGroupDn: configs.baseGroupDn,
-    useCase: configs.ldapUseCase
+    useCase: configs.ldapUseCase,
+    memberAttributeReferencedInGroup: configs.memberAttributeReferencedInGroup,
+    groupAttributeHoldingMember: configs.groupAttributeHoldingMember
   }
 
   if (isAttrStore) {
-    settings.memberAttributeReferencedInGroup = configs.memberAttributeReferencedInGroup
     settings.groupObjectClass = configs.groupObjectClass
-    settings.groupAttributeHoldingMember = configs.groupAttributeHoldingMember
   }
 
   return (

--- a/ui/src/main/webapp/wizards/ldap/stages/directory-settings.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/directory-settings.js
@@ -246,9 +246,12 @@ const DirectorySettings = (props) => {
   const isAttrStore = ldapUseCase === 'AuthenticationAndAttributeStore' || ldapUseCase === 'AttributeStore'
   const nextStageId = isAttrStore ? 'attribute-mapping' : 'confirm'
 
+  const connKey = Object.keys(configs.connectionInfo)[0]
+  const connInfo = configs.connectionInfo[connKey]
+
   const conn = {
-    hostname: configs.hostname,
-    port: configs.port,
+    hostname: connInfo[0],
+    port: connInfo[1],
     encryption: configs.encryption
   }
 

--- a/ui/src/main/webapp/wizards/ldap/stages/directory-settings.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/directory-settings.js
@@ -245,12 +245,9 @@ const DirectorySettings = (props) => {
   const isAttrStore = ldapUseCase === 'AuthenticationAndAttributeStore' || ldapUseCase === 'AttributeStore'
   const nextStageId = isAttrStore ? 'attribute-mapping' : 'confirm'
 
-  const connKey = Object.keys(configs.connectionInfo)[0]
-  const connInfo = configs.connectionInfo[connKey]
-
   const conn = {
-    hostname: connInfo[0],
-    port: connInfo[1],
+    hostname: configs.connectionList[0].hostname,
+    port: configs.connectionList[0].port,
     encryption: configs.encryption
   }
 

--- a/ui/src/main/webapp/wizards/ldap/stages/directory-settings.spec.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/directory-settings.spec.js
@@ -13,7 +13,8 @@ describe('<LDAP />', () => {
       const wrapper = shallow(
         <DirectorySettings
           configs={{
-            ldapUseCase: 'Authentication'
+            ldapUseCase: 'Authentication',
+            connectionInfo: [['localhost', '636', 'ldaps']]
           }}
           options={{}}
           errors={[]}
@@ -48,7 +49,8 @@ describe('<LDAP />', () => {
       const wrapper = shallow(
         <DirectorySettings
           configs={{
-            ldapUseCase: 'AttributeStore'
+            ldapUseCase: 'AttributeStore',
+            connectionInfo: [['localhost', '636', 'ldaps']]
           }}
           options={{}}
           errors={[]}
@@ -63,7 +65,8 @@ describe('<LDAP />', () => {
       const wrapper = shallow(
         <DirectorySettings
           configs={{
-            ldapUseCase: 'AuthenticationAndAttributeStore'
+            ldapUseCase: 'AuthenticationAndAttributeStore',
+            connectionInfo: [['localhost', '636', 'ldaps']]
           }}
           options={{}}
           errors={[]}

--- a/ui/src/main/webapp/wizards/ldap/stages/directory-settings.spec.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/directory-settings.spec.js
@@ -33,7 +33,8 @@ describe('<LDAP />', () => {
         'baseUserDn',
         'loginUserAttribute',
         'memberAttributeReferencedInGroup',
-        'baseGroupDn'
+        'baseGroupDn',
+        'groupAttributeHoldingMember'
       ])
 
       const notVisible = wrapper.find(InputAuto)
@@ -41,8 +42,7 @@ describe('<LDAP />', () => {
         .map((comp) => comp.prop('id'))
 
       expect(notVisible).to.deep.equal([
-        'groupObjectClass',
-        'groupAttributeHoldingMember'
+        'groupObjectClass'
       ])
     })
     it('should show all fields when `AttributeStore`', () => {

--- a/ui/src/main/webapp/wizards/ldap/stages/directory-settings.spec.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/directory-settings.spec.js
@@ -14,7 +14,7 @@ describe('<LDAP />', () => {
         <DirectorySettings
           configs={{
             ldapUseCase: 'Authentication',
-            connectionInfo: [['localhost', '636', 'ldaps']]
+            connectionList: [{hostname: 'localhost', port: '636', encryption: 'ldaps'}]
           }}
           options={{}}
           errors={[]}
@@ -50,7 +50,7 @@ describe('<LDAP />', () => {
         <DirectorySettings
           configs={{
             ldapUseCase: 'AttributeStore',
-            connectionInfo: [['localhost', '636', 'ldaps']]
+            connectionList: [{hostname: 'localhost', port: '636', encryption: 'ldaps'}]
           }}
           options={{}}
           errors={[]}
@@ -66,7 +66,7 @@ describe('<LDAP />', () => {
         <DirectorySettings
           configs={{
             ldapUseCase: 'AuthenticationAndAttributeStore',
-            connectionInfo: [['localhost', '636', 'ldaps']]
+            connectionList: [{hostname: 'localhost', port: '636', encryption: 'ldaps'}]
           }}
           options={{}}
           errors={[]}

--- a/ui/src/main/webapp/wizards/ldap/stages/network-settings.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/network-settings.js
@@ -52,18 +52,15 @@ class NetworkSettings extends Component {
     const {
         onEdit,
         configs: {
-          connectionInfo = {}
+          connectionList = []
         } = {}
       } = this.props
 
-    const filtered = Object.keys(connectionInfo).filter((_, i) => {
+    const filtered = connectionList.filter((_, i) => {
       return this.state.selected.indexOf(i) === -1
-    }).reduce((o, key) => {
-      o[key] = connectionInfo[key]
-      return o
-    }, {})
+    })
 
-    onEdit('connectionInfo')(filtered)
+    onEdit('connectionList')(filtered)
     this.setState({ selected: [] })
   }
 
@@ -75,7 +72,7 @@ class NetworkSettings extends Component {
       next,
       configs,
       configs: {
-        connectionInfo = {}
+        connectionList = []
       } = {},
       onEdit,
       onError,
@@ -91,7 +88,7 @@ class NetworkSettings extends Component {
 
     const isPortInvalid = configs.port === undefined || configs.port < 0 || configs.port > 65535
 
-    const missingHost = configs.connectionInfo === undefined || Object.keys(configs.connectionInfo).length === 0
+    const missingHost = configs.connectionList === undefined || configs.connectionList.length === 0
 
     return (
       <div>
@@ -152,13 +149,11 @@ class NetworkSettings extends Component {
                 port: configs.port,
                 encryption: configs.encryption
               })).then((result) => {
+                let updatedConnections = connectionList.concat([{hostname: configs.hostname, port: configs.port}])
                 onEdit({
                   hostname: '',
                   messages: [],
-                  connectionInfo: {
-                    ...connectionInfo,
-                    [Date.now()]: [configs.hostname, configs.port]
-                  }
+                  connectionList: updatedConnections
                 })
                 onError([])
                 onEndSubmit()
@@ -176,10 +171,10 @@ class NetworkSettings extends Component {
               </TableRow>
             </TableHeader>
             <TableBody showRowHover deselectOnClickaway={false}>
-              {Object.keys(connectionInfo).map((connInfo, i) =>
+              {connectionList.map((connection, i) =>
                 <TableRow key={i} selected={this.state.selected === 'all' || this.state.selected.indexOf(i) > -1}>
-                  <TableRowColumn>{connectionInfo[connInfo][0]}</TableRowColumn>
-                  <TableRowColumn>{connectionInfo[connInfo][1]}</TableRowColumn>
+                  <TableRowColumn>{connection.hostname}</TableRowColumn>
+                  <TableRowColumn>{connection.port}</TableRowColumn>
                 </TableRow>
               )}
             </TableBody>

--- a/ui/src/main/webapp/wizards/ldap/stages/network-settings.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/network-settings.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Component } from 'react'
 
 import { gql, withApollo } from 'react-apollo'
 
@@ -17,6 +17,17 @@ import {
   Select
 } from 'admin-wizard/inputs'
 
+import {
+    Table,
+    TableBody,
+    TableHeader,
+    TableHeaderColumn,
+    TableRow,
+    TableRowColumn
+} from 'material-ui/Table'
+
+import RaisedButton from 'material-ui/RaisedButton'
+
 import { groupErrors } from './errors'
 import {getFriendlyMessage} from 'graphql-errors'
 
@@ -32,87 +43,167 @@ const testConnect = (conn) => ({
   variables: { conn }
 })
 
-const NetworkSettings = (props) => {
-  const {
-    client,
-    setDefaults,
-    prev,
-    next,
-    configs,
-    onEdit,
-    onError,
-    onStartSubmit,
-    onEndSubmit
-  } = props
+class NetworkSettings extends Component {
+  constructor (props) {
+    super(props)
+    this.state = { selected: [] }
+  }
+  filterUpdateHosts () {
+    const {
+        onEdit,
+        configs: {
+          connectionInfo = {}
+        } = {}
+      } = this.props
 
-  const { messages, ...errors } = groupErrors([
-    'hostname',
-    'port',
-    'encryption'
-  ], props.errors)
+    const filtered = Object.keys(connectionInfo).filter((_, i) => {
+      return this.state.selected.indexOf(i) === -1
+    }).reduce((o, key) => {
+      o[key] = connectionInfo[key]
+      return o
+    }, {})
 
-  const isPortInvalid = configs.port === undefined || configs.port < 0 || configs.port > 65535
+    onEdit('connectionInfo')(filtered)
+    this.setState({ selected: [] })
+  }
 
-  return (
-    <div>
-      <Mount
-        on={setDefaults}
-        port={636}
-        encryption='ldaps' />
+  render () {
+    const {
+      client,
+      setDefaults,
+      prev,
+      next,
+      configs,
+      configs: {
+        connectionInfo = {}
+      } = {},
+      onEdit,
+      onError,
+      onStartSubmit,
+      onEndSubmit
+    } = this.props
 
-      <Title>LDAP Network Settings</Title>
-      <Description>
-        To establish a connection to the remote LDAP store, we need the hostname of the
-        LDAP machine, the port number that the LDAP service is running on, and the
-        encryption method. Typically, port 636 uses LDAPS encryption and port 389 uses
-        StartTLS.
-      </Description>
+    const { messages, ...errors } = groupErrors([
+      'hostname',
+      'port',
+      'encryption'
+    ], this.props.errors)
 
-      <Body>
-        <Hostname
-          value={configs.hostname}
-          errorText={errors.hostname}
-          onEdit={onEdit('hostname')}
-          autoFocus />
+    const isPortInvalid = configs.port === undefined || configs.port < 0 || configs.port > 65535
 
-        <Port
-          value={configs.port}
-          errorText={isPortInvalid ? getFriendlyMessage('INVALID_PORT_RANGE') : errors.port}
-          onEdit={onEdit('port')}
-          options={[389, 636]} />
+    const missingHost = configs.connectionInfo === undefined || Object.keys(configs.connectionInfo).length === 0
 
-        <Select
-          value={configs.encryption}
-          errorText={errors.encryption}
-          onEdit={onEdit('encryption')}
-          label='Encryption Method'
-          options={[ 'none', 'ldaps', 'startTls' ]} />
+    return (
+      <div>
+        <Mount
+          on={setDefaults}
+          port={636}
+          encryption='ldaps'
+          loadbalancing='round_robin' />
 
-        <Navigation>
-          <Back onClick={prev} />
-          <Next disabled={isPortInvalid}
+        <Title>LDAP Network Settings</Title>
+        <Description>
+          To establish a connection to the remote LDAP store, we need the hostname of the
+          LDAP machine, the port number that the LDAP service is running on, and the
+          encryption method. Typically, port 636 uses LDAPS encryption and port 389 uses
+          StartTLS.  Adding more than one host creates a cluster.  The cluster connections can
+          be load balanced between the hosts (round-robin) or can be treated as a failover cluster
+          where the first host is considered the primary host.
+        </Description>
+
+        <Body>
+          <Hostname
+            value={configs.hostname}
+            errorText={errors.hostname}
+            onEdit={onEdit('hostname')}
+            autoFocus />
+
+          <Port
+            value={configs.port}
+            errorText={isPortInvalid ? getFriendlyMessage('INVALID_PORT_RANGE') : errors.port}
+            onEdit={onEdit('port')}
+            options={[389, 636]} />
+
+          {messages.map((msg, i) => <Message key={i} {...msg} />)}
+
+          <RaisedButton
+            primary
+            style={{margin: '0 auto', marginBottom: '30px', marginTop: '10px', display: 'block'}}
+            label='Add Host'
+            disabled={isPortInvalid}
             onClick={() => {
               onStartSubmit()
               client.query(testConnect({
                 hostname: configs.hostname,
                 port: configs.port,
                 encryption: configs.encryption
-              }))
-                .then(() => {
-                  onEndSubmit()
-                  next('bind-settings')
+              })).then((result) => {
+                onEdit({
+                  hostname: '',
+                  messages: [],
+                  connectionInfo: {
+                    ...connectionInfo,
+                    [Date.now()]: [configs.hostname, configs.port]
+                  }
                 })
-                .catch((err) => {
-                  onEndSubmit()
-                  onError(err)
-                })
-            }}
-          />
-        </Navigation>
-        {messages.map((msg, i) => <Message key={i} {...msg} />)}
-      </Body>
-    </div>
-  )
+                onError([])
+                onEndSubmit()
+              }).catch((err) => {
+                onError(err)
+                onEndSubmit()
+              })
+            }} />
+
+          <Table multiSelectable onRowSelection={(selected) => this.setState({ selected })}>
+            <TableHeader displaySelectAll={false} >
+              <TableRow>
+                <TableHeaderColumn>Host</TableHeaderColumn>
+                <TableHeaderColumn>Port</TableHeaderColumn>
+              </TableRow>
+            </TableHeader>
+            <TableBody showRowHover deselectOnClickaway={false}>
+              {Object.keys(connectionInfo).map((connInfo, i) =>
+                <TableRow key={i} selected={this.state.selected === 'all' || this.state.selected.indexOf(i) > -1}>
+                  <TableRowColumn>{connectionInfo[connInfo][0]}</TableRowColumn>
+                  <TableRowColumn>{connectionInfo[connInfo][1]}</TableRowColumn>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+          <RaisedButton
+            label='Remove Selected Hosts'
+            primary
+            style={{ display: 'block', marginTop: 20 }}
+            disabled={this.state.selected.length === 0}
+            onClick={this.filterUpdateHosts.bind(this)} />
+
+          <Select
+            value={configs.encryption}
+            errorText={errors.encryption}
+            onEdit={onEdit('encryption')}
+            label='Encryption Method'
+            options={[ 'none', 'ldaps', 'startTls' ]} />
+
+          <Select
+            value={configs.loadbalancing}
+            onEdit={onEdit('loadbalancing')}
+            label='Load Balancing Algorithm'
+            options={[ 'round_robin', 'failover' ]} />
+
+          <Navigation>
+            <Back onClick={prev} />
+            <Next disabled={missingHost}
+              onClick={() => {
+                onStartSubmit()
+                onEndSubmit()
+                next('bind-settings')
+              }}
+            />
+          </Navigation>
+        </Body>
+      </div>
+    )
+  }
 }
 
 export default withApollo(NetworkSettings)

--- a/ui/src/main/webapp/wizards/ldap/stages/network-settings.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/network-settings.js
@@ -99,7 +99,7 @@ class NetworkSettings extends Component {
           on={setDefaults}
           port={636}
           encryption='ldaps'
-          loadbalancing='round_robin' />
+          loadbalancing='roundRobin' />
 
         <Title>LDAP Network Settings</Title>
         <Description>
@@ -108,10 +108,18 @@ class NetworkSettings extends Component {
           encryption method. Typically, port 636 uses LDAPS encryption and port 389 uses
           StartTLS.  Adding more than one host creates a cluster.  The cluster connections can
           be load balanced between the hosts (round-robin) or can be treated as a failover cluster
-          where the first host is considered the primary host.
+          where the first host is considered the primary host.  The configuration of each host
+          in the cluster is assumed to be the same (i.e. bind user, directory settings, etc).
         </Description>
 
         <Body>
+          <Select
+            value={configs.encryption}
+            errorText={errors.encryption}
+            onEdit={onEdit('encryption')}
+            label='Encryption Method'
+            options={[ 'none', 'ldaps', 'startTls' ]} />
+
           <Hostname
             value={configs.hostname}
             errorText={errors.hostname}
@@ -123,6 +131,12 @@ class NetworkSettings extends Component {
             errorText={isPortInvalid ? getFriendlyMessage('INVALID_PORT_RANGE') : errors.port}
             onEdit={onEdit('port')}
             options={[389, 636]} />
+
+          <Select
+            value={configs.loadbalancing}
+            onEdit={onEdit('loadbalancing')}
+            label='Load Balancing Algorithm'
+            options={[ 'roundRobin', 'failover' ]} />
 
           {messages.map((msg, i) => <Message key={i} {...msg} />)}
 
@@ -176,19 +190,6 @@ class NetworkSettings extends Component {
             style={{ display: 'block', marginTop: 20 }}
             disabled={this.state.selected.length === 0}
             onClick={this.filterUpdateHosts.bind(this)} />
-
-          <Select
-            value={configs.encryption}
-            errorText={errors.encryption}
-            onEdit={onEdit('encryption')}
-            label='Encryption Method'
-            options={[ 'none', 'ldaps', 'startTls' ]} />
-
-          <Select
-            value={configs.loadbalancing}
-            onEdit={onEdit('loadbalancing')}
-            label='Load Balancing Algorithm'
-            options={[ 'round_robin', 'failover' ]} />
 
           <Navigation>
             <Back onClick={prev} />


### PR DESCRIPTION
ABBREVIATED REVIEW BETWEEN 1.2.X AND MASTER
Link to 1.2.x PR: [#212](https://github.com/connexta/admin-console/pull/212)

#### What does this PR do?

Remove LDAP structure assumptions, provide better default values, enable LDAP login and attribute claims to work with nested user OUs, allow multiple ldap servers in a single configuration for load balancing / failover.

This is a companion PR to this [DDF-4090 PR](https://github.com/codice/ddf/pull/3767)

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@coyotesqrl 
@tbatie
@stustison
@peterhuffer
@djblue

#### How should this be tested? (List steps with links to updated documentation)

This needs to be built and deployed with this [DDF-4090 PR](https://github.com/codice/ddf/pull/3767).

Create or setup two identical LDAP servers (can be on the same machine if using different ports):
Create a user in a nested OU under the base user DN
Set their uid and cn to be different values (e.g. uid=user1, cn=User One)
Add the user to a group with uid as the member attribute in the group reference
Repeat for another user but utilize cn as the member attribute in the group reference

Verify that an LDAP configuration can be created by selecting either uid or cn as the member attribute in the group reference.
Verify that both LDAP servers can be added to a single configuration through the LDAP setup wizard

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-4090](https://codice.atlassian.net/browse/DDF-4090)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
