### PR TITLE
Fix pipeline due to unavailable service

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,25 +99,6 @@ pipeline {
                        }
                     }
                 }
-                stage('nodeJsSecurity') {
-                    agent { label 'linux-small' }
-                    steps {
-                        script {
-                            def packageFiles = findFiles(glob: '**/package.json')
-                            for (int i = 0; i < packageFiles.size(); i++) {
-                                dir(packageFiles[i].path.split('package.json')[0]) {
-                                    def packageFile = readJSON file: 'package.json'
-                                    if (packageFile.scripts =~ /.*webpack.*/ || packageFile.containsKey("browserify")) {
-                                        nodejs(configId: 'npmrc-default', nodeJSInstallationName: 'nodejs') {
-                                            echo "Scanning ${packageFiles[i].path}"
-                                            sh 'nsp check'
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
             }
         }
         /*

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
         <gib.referenceBranch>refs/remotes/origin/master</gib.referenceBranch>
         <gib.baseBranch>HEAD</gib.baseBranch>
         <gib.enabled>false</gib.enabled>
+        <gib.failOnError>false</gib.failOnError>
     </properties>
 
     <scm>


### PR DESCRIPTION
#### What does this PR do?
- Removes the `nsp check` since the Node Security Platform is no longer available. This causes a network error during the security checks.
- Ignore GIB failures to prevent build from failing. If GIB cannot calculate what to build, default will go back to full build of PR.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@coyotesqrl @oconnormi 

#### How should this be tested? (List steps with links to updated documentation)
Full build.

#### Any background context you want to provide?
See: https://blog.npmjs.org/post/175511531085/the-node-security-platform-service-is-shutting

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
