### PR TITLE
DDF-2985 Declare transitive dependencies no longer available in catalog-core-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <slf4j-api.version>1.7.24</slf4j-api.version>
         <osgi.version>6.0.0</osgi.version>
         <osgi.compendium.version>5.0.0</osgi.compendium.version>
+        <commons-lang3.version>3.8</commons-lang3.version>
 
         <ddf.scm.connection.url />
         <snapshots.repository.url />

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <ddf.version>2.13.5</ddf.version>
+        <ddf.version>2.13.6-SNAPSHOT</ddf.version>
         <ddf.support.version>2.3.9</ddf.support.version>
         <guava.version>20.0</guava.version>
         <karaf.version>4.2.1</karaf.version>

--- a/query/app/src/main/resources/features.xml
+++ b/query/app/src/main/resources/features.xml
@@ -34,6 +34,7 @@
     <feature name="admin-query-federation" install="manual" version="${project.version}"
              description="DDF :: Admin Console :: Query :: Federation">
         <feature>admin-query-core</feature>
+        <bundle>mvn:org.apache.commons/commons-lang3/${commons-lang3.version}</bundle>
         <bundle>mvn:org.codice.ddf.admin.query/admin-query-sources-impl/${project.version}</bundle>
     </feature>
 

--- a/query/sources/common/pom.xml
+++ b/query/sources/common/pom.xml
@@ -60,6 +60,11 @@
             <artifactId>catalog-core-api</artifactId>
             <version>${ddf.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
#### What does this PR do?
Update dependencies since catalog-core-api no longer supplies them.
Fix admin-query-sources-impl install
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@peterhuffer @tbatie 
#### How should this be tested? (List steps with links to updated documentation)
I will let Peter and Tracy decide that.
#### Any background context you want to provide?
This is a port from master
