### PR TITLE
Updated DDF to 2.15.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,9 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <ddf.version>2.14.0-SNAPSHOT</ddf.version>
+        <ddf.version>2.15.0-SNAPSHOT</ddf.version>
         <ddf.support.version>2.3.9</ddf.support.version>
+        <codice-test.version>0.3</codice-test.version>
         <guava.version>20.0</guava.version>
         <karaf.version>4.1.2</karaf.version>
         <groovy.version>2.4.7</groovy.version>
@@ -107,9 +108,16 @@
         </dependency>
         <!--Spock dependencies-->
         <dependency>
-            <groupId>ddf.lib</groupId>
-            <artifactId>spock-shaded</artifactId>
-            <version>${ddf.version}</version>
+            <groupId>org.codice.test</groupId>
+            <artifactId>spock-all</artifactId>
+            <version>${codice-test.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.test</groupId>
+            <artifactId>spock-extensions</artifactId>
+            <version>${codice-test.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tests/itests/pom.xml
+++ b/tests/itests/pom.xml
@@ -88,6 +88,12 @@
             <type>zip</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>${hamcrest-all.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -24,7 +24,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <pax.exam.version>4.11.0</pax.exam.version>
+        <pax.exam.version>4.13.1</pax.exam.version>
         <pax.tinybundles.version>2.1.1</pax.tinybundles.version>
         <pax.url.version>2.4.5</pax.url.version>
         <org.slf4j.version>1.7.1</org.slf4j.version>


### PR DESCRIPTION
#### What does this PR do?
Updates to DDF version 2.15.0-SNAPSHOT and updates the spock dependencies. Without this, downstream projects are starting duplicates of both 2.14.0-SNAPSHOT and 2.15.0-SNAPSHOT.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@peterhuffer @emmberk 
#### How should this be tested? (List steps with links to updated documentation)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
