### PR TITLE
Remove DDF feature repos temporarily

### DIFF
--- a/features/admin-query/pom.xml
+++ b/features/admin-query/pom.xml
@@ -146,9 +146,10 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-            </plugin>
+            <!-- TODO: Uncomment once https://github.com/connexta/admin-console/issues/246 is complete. -->
+            <!--<plugin>-->
+                <!--<artifactId>maven-failsafe-plugin</artifactId>-->
+            <!--</plugin>-->
         </plugins>
     </build>
 </project>

--- a/features/admin-query/src/main/feature/feature.xml
+++ b/features/admin-query/src/main/feature/feature.xml
@@ -16,9 +16,10 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
 
-    <repository>mvn:ddf.features/admin/${ddf.version}/xml/features</repository>
-    <repository>mvn:ddf.features/security/${ddf.version}/xml/features</repository>
-    <repository>mvn:ddf.catalog/catalog-app/${ddf.version}/xml/features</repository>
+    <!-- TODO: Uncomment and put in version ranges once https://github.com/connexta/admin-console/issues/246 is complete. -->
+    <!--<repository>mvn:ddf.features/admin/${ddf.version}/xml/features</repository>-->
+    <!--<repository>mvn:ddf.features/security/${ddf.version}/xml/features</repository>-->
+    <!--<repository>mvn:ddf.catalog/catalog-app/${ddf.version}/xml/features</repository>-->
 
     <feature name="admin-query-api" install="manual" version="${project.version}"
              description="DDF :: Admin Console :: Query :: Api ">

--- a/features/dev/pom.xml
+++ b/features/dev/pom.xml
@@ -83,9 +83,10 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-            </plugin>
+            <!-- TODO: Uncomment once https://github.com/connexta/admin-console/issues/246 is complete. -->
+            <!--<plugin>-->
+                <!--<artifactId>maven-failsafe-plugin</artifactId>-->
+            <!--</plugin>-->
         </plugins>
     </build>
 </project>

--- a/features/dev/src/main/feature/feature.xml
+++ b/features/dev/src/main/feature/feature.xml
@@ -17,7 +17,8 @@
           xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
 
     <repository>mvn:ddf.features/admin-query/${project.version}/xml/features</repository>
-    <repository>mvn:ddf.features/admin/${ddf.version}/xml/features</repository>
+    <!-- TODO: Uncomment and put in version ranges once https://github.com/connexta/admin-console/issues/246 is complete. -->
+    <!--<repository>mvn:ddf.features/admin/${ddf.version}/xml/features</repository>-->
 
     <feature name="admin-query-dev-tools" install="auto" version="${project.version}"
              description="Includes tools strictly for development purposes.">

--- a/features/testing/pom.xml
+++ b/features/testing/pom.xml
@@ -82,9 +82,10 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-            </plugin>
+            <!-- TODO: Uncomment once https://github.com/connexta/admin-console/issues/246 is complete. -->
+            <!--<plugin>-->
+                <!--<artifactId>maven-failsafe-plugin</artifactId>-->
+            <!--</plugin>-->
         </plugins>
     </build>
 </project>

--- a/features/testing/src/main/feature/feature.xml
+++ b/features/testing/src/main/feature/feature.xml
@@ -17,7 +17,8 @@
           xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
 
     <repository>mvn:ddf.features/admin-query/${project.version}/xml/features</repository>
-    <repository>mvn:ddf.features/test-utilities/${ddf.version}/xml/features</repository>
+    <!-- TODO: Uncomment and put in version ranges once https://github.com/connexta/admin-console/issues/246 is complete. -->
+    <!--<repository>mvn:ddf.features/test-utilities/${ddf.version}/xml/features</repository>-->
 
     <feature name="admin-query-itest-commons" install="auto" version="${project.version}"
              description="Integration tests tools for the admin query artifacts.">


### PR DESCRIPTION
#### What does this PR do?
Removes DDF feature repos and disables the feature itests until we can upgrade Karaf. See #246 for details.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@peterhuffer @blen-desta 
#### How should this be tested? (List steps with links to updated documentation)
CI
Hero steps:
- Build admin-console on this PR
- Point downstream project to admin-console version `1.3.1-SNAPSHOT` and ddf version `2.16.0-SNAPSHOT`
- Build the downstream project
- Run and install the downstream project.
- Either tail the logs are do a `list -t 0 -s | grep -i ddf` every once in awhile, and make sure no `2.15.0` versioned DDF bundles are starting up.
#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
