### PR TITLE
Point to the local NVD server for OWASP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -471,6 +471,11 @@
                                 <artifactId>support-owasp</artifactId>
                                 <version>${ddf.support.version}</version>
                             </dependency>
+                            <dependency>
+                                <groupId>org.mariadb.jdbc</groupId>
+                                <artifactId>mariadb-java-client</artifactId>
+                                <version>2.4.1</version>
+                            </dependency>
                         </dependencies>
                         <configuration>
                             <failBuildOnCVSS>7</failBuildOnCVSS>
@@ -496,6 +501,20 @@
                             <nspAnalyzerEnabled>false</nspAnalyzerEnabled>
                             <!--Analyzes Ruby Gemfile.lock files, not OSGi bundles-->
                             <bundleAuditAnalyzerEnabled>false</bundleAuditAnalyzerEnabled>
+
+                            <!-- The following properties enable using a mirror for nist NVD data -->
+                            <cveUrl12Modified>${owasp.cveUrl12Modified}</cveUrl12Modified>
+                            <cveUrl20Modified>${owasp.cveUrl20Modified}</cveUrl20Modified>
+                            <cveUrl12Base>${owasp.cveUrl12Base}</cveUrl12Base>
+                            <cveUrl20Base>${owasp.cveUrl20Base}</cveUrl20Base>
+                            <!-- End NVD mirror configuration -->
+
+                            <!-- The following properties enable using a centralized nvd server -->
+                            <autoUpdate>${owasp.autoUpdate}</autoUpdate>
+                            <databaseDriverName>${owasp.database.driverName}</databaseDriverName>
+                            <connectionString>${owasp.database.url}</connectionString>
+                            <serverId>${owasp.serverId}</serverId>
+                            <!-- End Centralized NVD Server Configuration -->
                         </configuration>
                         <executions>
                             <execution>


### PR DESCRIPTION
#### What does this PR do?
The nightly build is currently breaking on OWASP. This fixes the OWASP configuration to point to the local NVD db.
```
[2019-06-16T02:47:44.049Z] [ERROR] Failed to execute goal org.owasp:dependency-check-maven:3.0.2:aggregate (aggregation) on project admin: One or more exceptions occurred during dependency-check analysis: One or more exceptions occurred during dependency-check analysis
[2019-06-16T02:47:44.049Z] [ERROR]     The download was interrupted; unable to complete the update
[2019-06-16T02:47:44.049Z] [ERROR] -> [Help 1]
[2019-06-16T02:47:44.049Z] [ERROR] 
[2019-06-16T02:47:44.049Z] [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[2019-06-16T02:47:44.049Z] [ERROR] Re-run Maven using the -X switch to enable full debug logging.
[2019-06-16T02:47:44.049Z] [ERROR] 
[2019-06-16T02:47:44.049Z] [ERROR] For more information about the errors and possible solutions, please read the following articles:
[2019-06-16T02:47:44.049Z] [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@peterhuffer @blen-desta 

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
